### PR TITLE
palace example notebooks

### DIFF
--- a/examples/palace_demo_cpw.ipynb
+++ b/examples/palace_demo_cpw.ipynb
@@ -1,0 +1,307 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "### Running Palace Simulations on GDSFactory+ Cloud\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactoryplus import sim\n",
+    "from sim_utils import plot_mesh_pv, print_job_summary, upload_simulation_dir\n",
+    "\n",
+    "\n",
+    "# uv pip install \"gplugins[palace] @ git+https://github.com/gdsfactory/gplugins.git@palace-api\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === Configuration ===\n",
+    "OUTPUT_DIR = \"./ihp_cpw\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "### Load a pcell from IHP PDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "from ihp import LAYER, PDK\n",
+    "\n",
+    "PDK.activate()\n",
+    "\n",
+    "\n",
+    "@gf.cell\n",
+    "def gsg_electrode(\n",
+    "    length: float = 100,\n",
+    "    s_width: float = 20,\n",
+    "    g_width: float = 40,\n",
+    "    gap_width: float = 15,\n",
+    "    layer=LAYER.TopMetal2drawing,\n",
+    ") -> gf.Component:\n",
+    "    \"\"\"\n",
+    "    Create a GSG (Ground-Signal-Ground) electrode.\n",
+    "\n",
+    "    Args:\n",
+    "        length: horizontal length of the electrodes\n",
+    "        s_width: width of the signal (center) electrode\n",
+    "        g_width: width of the ground electrodes\n",
+    "        gap_width: gap between signal and ground electrodes\n",
+    "        layer: layer for the metal\n",
+    "    \"\"\"\n",
+    "    c = gf.Component()\n",
+    "\n",
+    "    # Top ground electrode\n",
+    "    r1 = c << gf.c.rectangle((length, g_width), centered=True, layer=layer)\n",
+    "    r1.move((0, (g_width + s_width) / 2 + gap_width))\n",
+    "\n",
+    "    # Center signal electrode\n",
+    "    _r2 = c << gf.c.rectangle((length, s_width), centered=True, layer=layer)\n",
+    "\n",
+    "    # Bottom ground electrode\n",
+    "    r3 = c << gf.c.rectangle((length, g_width), centered=True, layer=layer)\n",
+    "    r3.move((0, -(g_width + s_width) / 2 - gap_width))\n",
+    "\n",
+    "    # Add ports at the gaps\n",
+    "    c.add_port(\n",
+    "        name=\"P1\",\n",
+    "        center=(-length / 2, -(s_width + gap_width) / 2),\n",
+    "        width=gap_width,\n",
+    "        orientation=0,\n",
+    "        port_type=\"electrical\",\n",
+    "        layer=layer,\n",
+    "    )\n",
+    "\n",
+    "    c.add_port(\n",
+    "        name=\"P2\",\n",
+    "        center=(-length / 2, (s_width + gap_width) / 2),\n",
+    "        width=gap_width,\n",
+    "        orientation=0,\n",
+    "        port_type=\"electrical\",\n",
+    "        layer=layer,\n",
+    "    )\n",
+    "\n",
+    "    c.add_port(\n",
+    "        name=\"P3\",\n",
+    "        center=(length / 2, (s_width + gap_width) / 2),\n",
+    "        width=gap_width,\n",
+    "        orientation=180,\n",
+    "        port_type=\"electrical\",\n",
+    "        layer=layer,\n",
+    "    )\n",
+    "\n",
+    "    c.add_port(\n",
+    "        name=\"P4\",\n",
+    "        center=(length / 2, -(s_width + gap_width) / 2),\n",
+    "        width=gap_width,\n",
+    "        orientation=180,\n",
+    "        port_type=\"electrical\",\n",
+    "        layer=layer,\n",
+    "    )\n",
+    "\n",
+    "    return c\n",
+    "\n",
+    "\n",
+    "c = gsg_electrode()\n",
+    "cc = c.copy()\n",
+    "cc.draw_ports()\n",
+    "cc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "### Generate the mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gplugins import palace_api as pa\n",
+    "\n",
+    "# Transmission lines (no substrate)\n",
+    "stack = pa.get_stack(substrate_thickness=2.0, air_above=300.0)\n",
+    "\n",
+    "\n",
+    "# Left CPW port (2 elements)\n",
+    "pa.configure_cpw_port(\n",
+    "    port_upper=c.ports[\"P2\"],\n",
+    "    port_lower=c.ports[\"P1\"],\n",
+    "    layer=\"topmetal2\",\n",
+    "    length=5.0,\n",
+    ")\n",
+    "\n",
+    "# Right CPW port (2 elements)\n",
+    "pa.configure_cpw_port(\n",
+    "    port_upper=c.ports[\"P3\"],\n",
+    "    port_lower=c.ports[\"P4\"],\n",
+    "    layer=\"topmetal2\",\n",
+    "    length=5.0,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# Extract → returns 2 CPWPort objects\n",
+    "ports = pa.extract_ports(c, stack)\n",
+    "\n",
+    "# Generate mesh\n",
+    "result = pa.generate_mesh(\n",
+    "    component=c,\n",
+    "    stack=stack,\n",
+    "    ports=ports,\n",
+    "    output_dir=OUTPUT_DIR,\n",
+    "    config=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Static PNG\n",
+    "plot_mesh_pv(f\"{OUTPUT_DIR}/palace.msh\", show_groups=[\"metal\", \"P\"], interactive=False)\n",
+    "\n",
+    "# Interactive\n",
+    "# plot_mesh_pv(f\"{OUTPUT_DIR}/palace.msh\", show_groups=['metal', 'P'], interactive=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "### Upload the mesh and start the simulation job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pre_job = upload_simulation_dir(OUTPUT_DIR, sim.JobDefinition.PALACE)\n",
+    "job = sim.start_simulation(pre_job)\n",
+    "finished_job = sim.wait_for_simulation(job)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_job_summary(finished_job)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = sim.download_results(finished_job)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_csv(results[\"port-S.csv\"])\n",
+    "df.columns = df.columns.str.strip()  # Remove whitespace from column names\n",
+    "\n",
+    "freq = df[\"f (GHz)\"]\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 6))\n",
+    "\n",
+    "# Magnitude plot\n",
+    "ax1.plot(freq, df[\"|S[1][1]| (dB)\"], marker=\".\", label=\"S11\")\n",
+    "ax1.plot(freq, df[\"|S[2][1]| (dB)\"], marker=\".\", label=\"S21\")\n",
+    "ax1.set_xlabel(\"Frequency (GHz)\")\n",
+    "ax1.set_ylabel(\"Magnitude (dB)\")\n",
+    "ax1.set_title(\"S-Parameters\")\n",
+    "ax1.legend()\n",
+    "ax1.grid(True)\n",
+    "\n",
+    "# Phase plot\n",
+    "ax2.plot(freq, df[\"arg(S[1][1]) (deg.)\"], marker=\".\", label=\"S11\")\n",
+    "ax2.plot(freq, df[\"arg(S[2][1]) (deg.)\"], marker=\".\", label=\"S21\")\n",
+    "ax2.set_xlabel(\"Frequency (GHz)\")\n",
+    "ax2.set_ylabel(\"Phase (deg)\")\n",
+    "ax2.legend()\n",
+    "ax2.grid(True)\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "IHP",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/palace_demo_microstrip.ipynb
+++ b/examples/palace_demo_microstrip.ipynb
@@ -1,0 +1,225 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "### Running Palace Simulations on GDSFactory+ Cloud\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gdsfactoryplus import sim\n",
+    "from sim_utils import plot_mesh_pv, print_job_summary, upload_simulation_dir\n",
+    "\n",
+    "\n",
+    "# uv pip install \"gplugins[palace] @ git+https://github.com/gdsfactory/gplugins.git@palace-api\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# === Configuration ===\n",
+    "OUTPUT_DIR = \"./ihp_microstrip\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "### Load a pcell from IHP PDK"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import gdsfactory as gf\n",
+    "\n",
+    "from ihp import LAYER, PDK, cells\n",
+    "\n",
+    "PDK.activate()\n",
+    "\n",
+    "c = gf.Component()\n",
+    "r1 = c << cells.straight_metal()\n",
+    "\n",
+    "r = c.get_region(layer=LAYER.TopMetal2drawing)\n",
+    "r_sized = r.sized(+5000)\n",
+    "c.add_polygon(r_sized, layer=LAYER.Metal1drawing)\n",
+    "\n",
+    "\n",
+    "c.add_ports(r1.ports)\n",
+    "\n",
+    "cc = c.copy()\n",
+    "cc.draw_ports()\n",
+    "cc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
+   "metadata": {},
+   "source": [
+    "### Generate the mesh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from gplugins import palace_api as pa\n",
+    "\n",
+    "# Get stack (no substrate for RF simulation)\n",
+    "stack = pa.get_stack(substrate_thickness=2.0, air_above=300.0)\n",
+    "\n",
+    "# Configure via ports (Metal1 to TopMetal2)\n",
+    "pa.configure_via_port(\n",
+    "    c.ports,\n",
+    "    from_layer=\"metal1\",\n",
+    "    to_layer=\"topmetal2\",\n",
+    "    impedance=50.0,\n",
+    ")\n",
+    "\n",
+    "ports = pa.extract_ports(c, stack)\n",
+    "\n",
+    "# Generate mesh\n",
+    "result = pa.generate_mesh(\n",
+    "    component=c,\n",
+    "    stack=stack,\n",
+    "    ports=ports,\n",
+    "    output_dir=OUTPUT_DIR,\n",
+    "    config=None,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Static PNG\n",
+    "plot_mesh_pv(f\"{OUTPUT_DIR}/palace.msh\", show_groups=[\"metal\", \"P\"], interactive=False)\n",
+    "\n",
+    "# Interactive\n",
+    "# plot_mesh_pv(f\"{OUTPUT_DIR}/palace.msh\", show_groups=['metal', 'P'], interactive=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8",
+   "metadata": {},
+   "source": [
+    "### Upload the mesh and start the simulation job"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pre_job = upload_simulation_dir(OUTPUT_DIR, sim.JobDefinition.PALACE)\n",
+    "job = sim.start_simulation(pre_job)\n",
+    "finished_job = sim.wait_for_simulation(job)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print_job_summary(finished_job)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "results = sim.download_results(finished_job)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_csv(results[\"port-S.csv\"])\n",
+    "df.columns = df.columns.str.strip()  # Remove whitespace from column names\n",
+    "\n",
+    "freq = df[\"f (GHz)\"]\n",
+    "\n",
+    "fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 6))\n",
+    "\n",
+    "# Magnitude plot\n",
+    "ax1.plot(freq, df[\"|S[1][1]| (dB)\"], marker=\".\", label=\"S11\")\n",
+    "ax1.plot(freq, df[\"|S[2][1]| (dB)\"], marker=\".\", label=\"S21\")\n",
+    "ax1.set_xlabel(\"Frequency (GHz)\")\n",
+    "ax1.set_ylabel(\"Magnitude (dB)\")\n",
+    "ax1.set_title(\"S-Parameters\")\n",
+    "ax1.legend()\n",
+    "ax1.grid(True)\n",
+    "\n",
+    "# Phase plot\n",
+    "ax2.plot(freq, df[\"arg(S[1][1]) (deg.)\"], marker=\".\", label=\"S11\")\n",
+    "ax2.plot(freq, df[\"arg(S[2][1]) (deg.)\"], marker=\".\", label=\"S21\")\n",
+    "ax2.set_xlabel(\"Frequency (GHz)\")\n",
+    "ax2.set_ylabel(\"Phase (deg)\")\n",
+    "ax2.legend()\n",
+    "ax2.grid(True)\n",
+    "\n",
+    "plt.tight_layout()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "IHP",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/sim_utils.py
+++ b/examples/sim_utils.py
@@ -1,0 +1,104 @@
+# this will be in the next version of gdsfactoryplus
+import zipfile
+from pathlib import Path
+
+import meshio
+import pyvista as pv
+from gdsfactoryplus import sim
+from IPython.display import Image, display
+
+
+def upload_simulation_dir(
+    input_dir: str | Path,
+    job_definition: sim.JobDefinition,
+) -> sim.PreJob:
+    """Zip all files in a directory (recursively) and upload for simulation."""
+    input_dir = Path(input_dir)
+    zip_path = Path("simulation_zipfile.zip")
+
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_STORED) as zf:
+        for file in input_dir.rglob("*"):
+            if file.is_file():
+                zf.write(file, arcname=file.relative_to(input_dir))
+
+    pre_job = sim.upload_simulation(path=zip_path, job_definition=job_definition)
+    zip_path.unlink()  # Delete the zip file
+    return pre_job
+
+
+def print_job_summary(job):
+    """Print a concise summary of a simulation job."""
+    if job.started_at and job.finished_at:
+        delta = job.finished_at - job.started_at
+        minutes, seconds = divmod(int(delta.total_seconds()), 60)
+        duration = f"{minutes}m {seconds}s"
+    else:
+        duration = "N/A"
+
+    size_kb = job.output_size_bytes / 1024
+    size_str = f"{size_kb:.1f} KB" if size_kb < 1024 else f"{size_kb / 1024:.2f} MB"
+    files = list(job.download_urls.keys()) if job.download_urls else []
+
+    print(f"{'Job:':<12} {job.job_name}")
+    print(f"{'Status:':<12} {job.status.value} (exit {job.exit_code})")
+    print(f"{'Duration:':<12} {duration}")
+    print(
+        f"{'Resources:':<12} {job.requested_cpu} CPU / {job.requested_memory_mb // 1024} GB"
+    )
+    print(f"{'Output:':<12} {size_str}")
+    print(f"{'Files:':<12} {len(files)} files")
+    for f in files:
+        print(f"             - {f}")
+
+
+def plot_mesh_pv(msh_path, output="mesh.png", show_groups=None, interactive=True):
+    """Plot mesh wireframe using PyVista.
+
+    Args:
+        msh_path: Path to .msh file
+        output: Output PNG path (ignored if interactive=True)
+        show_groups: List of group name patterns to show (None = all)
+        interactive: If True, open interactive viewer
+    """
+    # Get group info
+    mio = meshio.read(msh_path)
+    group_map = {tag: name for name, (tag, dim) in mio.field_data.items()}
+
+    mesh = pv.read(msh_path)
+
+    if interactive:
+        plotter = pv.Plotter(window_size=[1200, 900])
+    else:
+        plotter = pv.Plotter(off_screen=True, window_size=[1200, 900])
+
+    plotter.set_background("white")
+
+    if show_groups:
+        ids = [
+            tag
+            for tag, name in group_map.items()
+            if any(p in name for p in show_groups)
+        ]
+        colors = ["red", "blue", "green", "orange", "purple", "cyan"]
+        for i, gid in enumerate(ids):
+            subset = mesh.extract_cells(mesh.cell_data["gmsh:physical"] == gid)
+            if subset.n_cells > 0:
+                plotter.add_mesh(
+                    subset,
+                    style="wireframe",
+                    color=colors[i % len(colors)],
+                    line_width=1,
+                    label=group_map.get(gid, str(gid)),
+                )
+        plotter.add_legend()
+    else:
+        plotter.add_mesh(mesh, style="wireframe", color="black", line_width=1)
+
+    plotter.camera_position = "iso"
+
+    if interactive:
+        plotter.show()
+    else:
+        plotter.screenshot(output)
+        plotter.close()
+        display(Image(output))


### PR DESCRIPTION
## Summary by Sourcery

Add example workflows demonstrating how to run Palace-based RF simulations on GDSFactory+ Cloud using IHP PDK layouts and shared utilities.

New Features:
- Introduce a CPW electrode Palace simulation notebook that builds an IHP PDK GSG structure, generates a 3D mesh, runs a cloud Palace job, and visualizes S-parameters.
- Add a microstrip Palace simulation notebook that creates a metal stack structure from the IHP PDK, sets up via ports, meshes the design, runs a cloud Palace job, and plots S-parameters.

Enhancements:
- Provide a reusable simulation utility module for zipping and uploading simulation directories, summarizing cloud jobs, and visualizing Palace meshes with PyVista for use in example notebooks.

Documentation:
- Add user-facing example notebooks documenting end-to-end Palace simulation flows for CPW and microstrip structures on GDSFactory+ Cloud.