### PR TITLE
update_gdsfactory9.34

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -639,7 +639,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.24.0"
+version = "9.34.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -651,6 +651,7 @@ dependencies = [
     { name = "loguru" },
     { name = "mapbox-earcut" },
     { name = "matplotlib" },
+    { name = "natsort" },
     { name = "networkx" },
     { name = "numpy" },
     { name = "orjson" },
@@ -674,9 +675,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/d1/93452f81f7db8bc300a5b5a7fb8026aa2a06e9022671f0cb784d49e230cc/gdsfactory-9.24.0.tar.gz", hash = "sha256:987cb7ee4f56a61590248266d126ffffc69919491776bb88591d81067686e516", size = 496043, upload-time = "2025-12-02T18:49:59.728Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/60/d451c9c6165c65d3ab1b772b24b468212b5e08c9c0218ea671fb058e4b40/gdsfactory-9.34.0.tar.gz", hash = "sha256:22b0c541b48e4d939c3492bf85dbd9a3f9d93b67c1b5495c6efb0ad09f88311e", size = 499833, upload-time = "2026-02-01T18:58:27.318Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/c4/8f8d4bcb0c7ca329fb45ceb929fbe1d423b8bfdb4d2cdf0911e353d6fb1b/gdsfactory-9.24.0-py3-none-any.whl", hash = "sha256:cde1551c09f117824e697a1cfdef616fe74ebbba1086ac3b750f5e32a722321e", size = 693569, upload-time = "2025-12-02T18:49:57.706Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/90/6f97dd3f2ff2c47b7579876ed9b5b8f014bb39f92b2704a1958f5a8b06dc/gdsfactory-9.34.0-py3-none-any.whl", hash = "sha256:ed6f490fcbe891726c4cfe42917600bd8560c93d1a3dd6889b2db85a64859fdb", size = 701493, upload-time = "2026-02-01T18:58:24.632Z" },
 ]
 
 [[package]]
@@ -805,7 +806,7 @@ docs = [
 requires-dist = [
     { name = "autodoc-pydantic", marker = "extra == 'docs'" },
     { name = "doroutes", specifier = ">=0.2.0" },
-    { name = "gdsfactory", specifier = "~=9.24.0" },
+    { name = "gdsfactory", specifier = "~=9.34.0" },
     { name = "gplugins", extras = ["sax"], specifier = "~=2.0.0" },
     { name = "jsondiff", marker = "extra == 'dev'" },
     { name = "jupyter-book", marker = "extra == 'docs'", specifier = "==1.0.3" },
@@ -1193,7 +1194,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "2.0.0"
+version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -1213,9 +1214,9 @@ dependencies = [
     { name = "toolz" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/c8/0baefdd6a8f2ffacf55cbd3215b110cb32c06b9b189795f42afb6264488e/kfactory-2.0.0.tar.gz", hash = "sha256:fb45f4bef299582efa02616313010663ecb22da777d5648cce99e2061a4c7b9c", size = 252053, upload-time = "2025-10-17T15:54:24.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/17/fc9cf193bac727408afe559f71797b638d4f63d09f32e99000197dd6b447/kfactory-2.3.0.tar.gz", hash = "sha256:401cf49e3bb6de4fb6df5f2a73adaf59f0cc11dac432124b8369d42ea6e7c91b", size = 13524472, upload-time = "2026-01-19T14:43:48.739Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/77/9564c61255283b448c0db12b60550f7f3e5d891defbac1ea02f6c2b71e73/kfactory-2.0.0-py3-none-any.whl", hash = "sha256:65d290ef0e289670605b6bc5baa92662d0fcb96ab24e9e4e13a2243694d0763c", size = 244208, upload-time = "2025-10-17T15:54:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/44/d8/8c484fbfbb7804aac2b63c86c1a5bd3052ad1280ce01f5438d7d8e8b23b9/kfactory-2.3.0-py3-none-any.whl", hash = "sha256:617f03400a7474ffb176274c1670783a3b67f6f1c3eca3239609cd7c994a7b78", size = 251947, upload-time = "2026-01-19T14:43:46.783Z" },
 ]
 
 [package.optional-dependencies]
@@ -1292,31 +1293,31 @@ wheels = [
 
 [[package]]
 name = "klayout"
-version = "0.30.4"
+version = "0.30.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/ae/c9cd4496a5f91865aea33cb52d17bbc0943797103237d99842dcfe43dfd7/klayout-0.30.4.tar.gz", hash = "sha256:96be7c49dbf61599577f6ab47db6d3c1078376bb5a6ed2d7119053b0d5ba9ba2", size = 3881273, upload-time = "2025-09-12T23:40:28.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/a9/04d916676303309c7d3ca78f63f7a8641a2d9bd10ca7a1c075763ac02381/klayout-0.30.5.tar.gz", hash = "sha256:579e4eecd763c3760e85ef0e2ac1dcc05878413e7649cacfe75eb8c0d3f8e207", size = 4135426, upload-time = "2025-11-12T23:46:11.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/42/3642bb443f5ca7b17daf6653c301736862389d16a639a5d2f2fd2287cecc/klayout-0.30.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6b99d21f2e449c6a064eaf4429aabbb48c44f82f00fc003e1ebeda011c620e75", size = 21661717, upload-time = "2025-09-12T23:38:56.477Z" },
-    { url = "https://files.pythonhosted.org/packages/da/c3/1ab760217fa31e2114800f1c89ccfb4b434b385a1f60a5ca9b5c4a373e94/klayout-0.30.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:656add0489304675984d8063dd9773484f3c6be7ebdd2663a26b0329a4a0f5f0", size = 19794145, upload-time = "2025-09-12T23:38:58.87Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/bb/a68bc115d319bf163ef6bcb0360bd7a8ecb7424d6215a41ebef491744710/klayout-0.30.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:59b7d86db88056920c05b70aadc14be1ecd1152224e198e2a17bf3d75f3c8241", size = 24073165, upload-time = "2025-09-12T23:39:00.943Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/b4/0105bded3e18bc4bfe9c44afc1c5095d3a743166f17de85ecba99bbb4f55/klayout-0.30.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:231a1bf6b14c779830bb4229f79da3d7be4e2a450bbe2b8051a4051239ce04f8", size = 25941310, upload-time = "2025-09-12T23:39:03.267Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/a1/da46d3311998e03efe4b544cd0d4787f39ca1daa5eaba176429bf87e3a89/klayout-0.30.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:6df77770443de6930c917f3eb86d4b871178101746cbcdf185f1d8075ad66a36", size = 27441388, upload-time = "2025-09-12T23:39:05.737Z" },
-    { url = "https://files.pythonhosted.org/packages/97/76/abe4f4b2c826af010ee31185ae10a9fd490b7e21d93a96dc59b1c4882b4a/klayout-0.30.4-cp311-cp311-win32.whl", hash = "sha256:a85b57708364124fbcdd9d83f2f2aae4a230c534755cf106b581af6495d4199b", size = 11601654, upload-time = "2025-09-12T23:12:08.689Z" },
-    { url = "https://files.pythonhosted.org/packages/83/80/b946b7c41efdd50c390c974c3a7b66753561c15e85fe84bf502305ec4bc8/klayout-0.30.4-cp311-cp311-win_amd64.whl", hash = "sha256:062603b486967ecfbdac01b73d7db7f8d64812d5a970766a126f4e4767162deb", size = 13297956, upload-time = "2025-09-12T23:12:10.91Z" },
-    { url = "https://files.pythonhosted.org/packages/37/63/9bed3a6e7427f9d84c8d12c77e704f4def2bc2b9ce54c9b96f66fd6fb5da/klayout-0.30.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3a879bf4335bb6da49e8a72cfab4d17477194db3188d0b64296bc19dc98ec532", size = 21249515, upload-time = "2025-09-12T23:39:07.893Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/63/9d2672948fe222a7d9061d660b0cb2ecc3de0d9edfc0badf33bcf5e74585/klayout-0.30.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:62b2a63ffa48b063e5f08b3284d69da9250509d748a814d0c4bde26edc270c8b", size = 19794359, upload-time = "2025-09-12T23:39:10.114Z" },
-    { url = "https://files.pythonhosted.org/packages/22/98/f80db973fbe022e965e4e9c9678f4cd0b099be4b11313bdc639b5d18ef6a/klayout-0.30.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:53616b6c7a0ecf5b1e6630ee24e18322dfcc5745658b92b4ce0e70983be4e7d2", size = 24086513, upload-time = "2025-09-12T23:39:15.183Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/ed/ef0a0a24fd5553b1e15b817de9c34378c0ea5d40ddf255a717711aed7887/klayout-0.30.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:06991ab316645f74b0e3a457d1ab38f3ef3d7d20c1634ff38b2abf98e2aa9e8d", size = 25959668, upload-time = "2025-09-12T23:39:17.432Z" },
-    { url = "https://files.pythonhosted.org/packages/26/92/ef283340dfd73dadea05155108ed67a4658d99ed320bb086b09dc7814fcf/klayout-0.30.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:79c98c833335de6b09e0c5ed59f39171859d148f73c852704d0bdb2e18e4d92f", size = 27460605, upload-time = "2025-09-12T23:39:19.663Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/21/708f99ce4113033b57e1bb99f25ada2c7abc80155514ca84f017877f6b8e/klayout-0.30.4-cp312-cp312-win32.whl", hash = "sha256:622507cb07f5f99ac2473aa730009409b4d5393ae986c1ad862eb278c852d291", size = 11602096, upload-time = "2025-09-12T23:12:13.019Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/72/6920da599353d2ca32d2680cebf58f6eebb2d8933cb17667a290c1b67760/klayout-0.30.4-cp312-cp312-win_amd64.whl", hash = "sha256:260007c01ef4506fe23829e57a9b2b3ad2a79b15439d5e7994aeb07543fb12da", size = 13297618, upload-time = "2025-09-12T23:12:15.041Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/d4/3240ebdaae9abf4faecb690316698471d69ae4ebe78bb48c12bde3213c34/klayout-0.30.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0c2fc8bd799e19c6afc485a7cccebf9e50e3cf3c9da03b6e25b342a5e4f8f9e1", size = 21249516, upload-time = "2025-09-12T23:39:22.358Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/85/da323cde7afb2d129d3c01e5a1f887a2ae03b5577b066cd7ee2ab8273312/klayout-0.30.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:62cfa746bfa897625b8a5c1d2a6682661919cf45bde31f2e5a4132b8e7b0e474", size = 19794337, upload-time = "2025-09-12T23:39:24.773Z" },
-    { url = "https://files.pythonhosted.org/packages/03/87/0d6263b6e302fb1055273019beecb9adbb12701a5c90397eb82fdda65a7b/klayout-0.30.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66b0106dd3c9d9ce01f49e9f9f5e80f27aa9c102301269f9288cbfdabb4c7811", size = 24086506, upload-time = "2025-09-12T23:39:27.06Z" },
-    { url = "https://files.pythonhosted.org/packages/be/8b/164e643bacd6cc3a7cf71be11602a5c3025f2b1e78bbe9a704ad87821091/klayout-0.30.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:aa18f93399e68819634a737268eee2a44d5813fe73fef53c062a458e58e43398", size = 25959696, upload-time = "2025-09-12T23:39:29.253Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/08/f4a447b64bb631b7a14ee593014051589e6ef0eb05ce534fde94e252791f/klayout-0.30.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:45effdbce8e65f87e9f493fd29ecbbf6d71634817fb88b7df0296f1f9045b800", size = 27460608, upload-time = "2025-09-12T23:39:31.465Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/2d/b15af4099d2d5ddcab5ec7db19f086439ff637e391b4f1ecc8aa157b6ea0/klayout-0.30.4-cp313-cp313-win32.whl", hash = "sha256:c9578241dc6a33dcb3c777dd3115e6eedc68857fd645c0f7602be2e2552f0385", size = 11602110, upload-time = "2025-09-12T23:12:17.792Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/ac/61d322fc53e8253fcc5d1aed4c16e3123c28c7fc2ec0891dfb71377cb11b/klayout-0.30.4-cp313-cp313-win_amd64.whl", hash = "sha256:f012e5cae1887310201927bbc07be695ba2361780716ff2ac4edd25b39e3a71a", size = 13294533, upload-time = "2025-09-12T23:12:19.984Z" },
+    { url = "https://files.pythonhosted.org/packages/81/d5/50016574d348aca66f3b07594174bc82cac552732acf025767b16b37dd36/klayout-0.30.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:09c27eed9ca802e92c2dbc7699507ea57f21313118f4fc9ca811936d8aa2f043", size = 22467790, upload-time = "2025-11-12T23:44:35.675Z" },
+    { url = "https://files.pythonhosted.org/packages/65/2a/914064f4135d46605f6c2911647fec862f5a384ba5d829415df31d0cd9b1/klayout-0.30.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:961639210694254dd6d6b0371fa20bf292142e5cf651a202f5d3b20a200bcdde", size = 20531152, upload-time = "2025-11-12T23:44:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/0d/9f8de368707e36907af921739e970fbc27f22c965d5150e71c9f472004e2/klayout-0.30.5-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48a753617a612959f60c7a74366095e230a3de8b9887d5fd30c45a2b97d87a69", size = 24857739, upload-time = "2025-11-12T23:44:40.755Z" },
+    { url = "https://files.pythonhosted.org/packages/73/0a/ad160223ed99dfd7018cdf130844692e02d9c31cb1ef9c72dc88ba02b270/klayout-0.30.5-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fa3541fa4e63b4b6fbeadc07d9b2840b8aba2194ecb4208f5b0c82065e89500d", size = 26782754, upload-time = "2025-11-12T23:44:43.373Z" },
+    { url = "https://files.pythonhosted.org/packages/82/00/ee191fefab2cce8926673c4e5d80c512bd4dbb848bedaaea5ee2c3a0f3b3/klayout-0.30.5-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:c6c006eeae38ddee42fbb13ce766301ce7d07ea025ea2b4c2fc3b9fc8ede26d0", size = 28312297, upload-time = "2025-11-12T23:44:45.876Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/70/c8bc217615cc61b7c6ae0a91c15d1202cd9851ecda2baac0f7b5152e63de/klayout-0.30.5-cp311-cp311-win32.whl", hash = "sha256:1b133197f056d8073211024e541b63e17c49e4a3c4916a5ab75ccd74384d9e0d", size = 11981599, upload-time = "2025-11-13T02:47:01.528Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/80/daa28eaf867282ede2e5f362c00fed82b98bf84a1a8dea703c16efdf6a13/klayout-0.30.5-cp311-cp311-win_amd64.whl", hash = "sha256:29ac703810382aafaef20529195bd9a9b1fc0420c3122ead3800b39e06b8b327", size = 13723791, upload-time = "2025-11-13T02:47:04.259Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/c6d9c1eb914c0bd654b181e39f57cde809b2d90f6cfad31b79aa3931211c/klayout-0.30.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0ca7552609802e462989df7e2b4f3d0d244257a14e63aa01b223a88a66437618", size = 22046172, upload-time = "2025-11-12T23:44:48.298Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/84/1c9294605223aaccaa73c119ae06f4b8172b028262c80334e7e9f390c34b/klayout-0.30.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:831e55ba1432ae96512adcf7a6e29a6f0239264e1350f0815bd4dcadbed7c73b", size = 20531429, upload-time = "2025-11-12T23:44:51.281Z" },
+    { url = "https://files.pythonhosted.org/packages/17/f2/1fceb496096f7f9b9939ce8f2e79b54a569c7fced9db4b93c392d4dfaa23/klayout-0.30.5-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7bd33bc4ffe2befe9277aee5aa98d59d06e9316021a2eef843525a42a4fa8cbb", size = 24874084, upload-time = "2025-11-12T23:44:53.918Z" },
+    { url = "https://files.pythonhosted.org/packages/55/17/ab3a667695cb4456fce45455724d24cddd86d7525001e1b218dbb54a1c01/klayout-0.30.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:395c803b1a48c50094afadc15094c65bb3b29f59ab8660810cfe7e456c50000d", size = 26802251, upload-time = "2025-11-12T23:44:57.393Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/1e/d1ddf199d76a329ab4b0b324831246eeebbde72a58ebe9ccd4df20738c05/klayout-0.30.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0961760dd31afb3f234a71a869a7badf370cc9f0422ee5af7098a0148007b2d1", size = 28335526, upload-time = "2025-11-12T23:45:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/6d/daa1e7d9d7726ad40ef1b17a027180ff797141614d2722ae07344670e939/klayout-0.30.5-cp312-cp312-win32.whl", hash = "sha256:8153c920978878d1938f615c758355d3aef2d2bece580c68c7111031fbd442e6", size = 11982053, upload-time = "2025-11-13T02:47:08.281Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/4b/0841b123470d0869df92d24cc9df90c2df496aaf9f7c1332628159b97d84/klayout-0.30.5-cp312-cp312-win_amd64.whl", hash = "sha256:a07884870a4190042dafd5d414e6146f4f7c0fe54ec3082a3c113f77efc8d274", size = 13723476, upload-time = "2025-11-13T02:47:10.355Z" },
+    { url = "https://files.pythonhosted.org/packages/66/44/96fc689fcba5506aa840286866185ce5d6bb43df9dc33350128e2d7fbd93/klayout-0.30.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:f73fd5575e55768c2dcbe7a4370dc86e138c6c6321a2f7edba5694889c822696", size = 22046091, upload-time = "2025-11-12T23:45:03.534Z" },
+    { url = "https://files.pythonhosted.org/packages/65/7b/b96ffac84012ee7adcce171ae7632cb9228e0274e4e28c9b2587a0a7a23a/klayout-0.30.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f694e6c86f1445e58015c4635b5847369c38be1825673dfb941e56e0d1d3b67", size = 20531338, upload-time = "2025-11-12T23:45:05.899Z" },
+    { url = "https://files.pythonhosted.org/packages/00/50/899ead3f20520df6ace7738070ce738b4bc9a5d52cafa0400c0a01c10226/klayout-0.30.5-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24ee7724f3871c1c469cd8994337b42cd784445d4414482aaf08809523f237ad", size = 24874077, upload-time = "2025-11-12T23:45:08.751Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/0a/df726d14586987968c00c6af10a6694b7fa6b652e316218cff3f8e10607a/klayout-0.30.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd601badf644ea1d7e93bb7ea43dce0231661c082c7dd25064489696a282ee63", size = 26802265, upload-time = "2025-11-12T23:45:11.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/3810fac2274ccee453b8b39cb4953e692219181c4021291f9d89652e7b8a/klayout-0.30.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e57fa2b039cc1714be1a4ae2252f6b7c80572192db8b2c906aefe6df26316560", size = 28335531, upload-time = "2025-11-12T23:45:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/85/a5a8876a98028b2748231723f03551a0f6ea60bbb0a210ee059ce852e2f6/klayout-0.30.5-cp313-cp313-win32.whl", hash = "sha256:89fde645dbced23ceeb54cbf895e109da364fb406ecc647f53b7ab3990d6b295", size = 11982054, upload-time = "2025-11-13T02:47:12.241Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6d/ee53d0b6ead3bfb998659301eaacf827265dbbeceac75c65dfb9d2d2e0fd/klayout-0.30.5-cp313-cp313-win_amd64.whl", hash = "sha256:6cace034e42f13dfddf67c4e747f6e839f415073d7faa30e0eec9f6b4c369bf2", size = 13723626, upload-time = "2025-11-13T02:47:15.899Z" },
 ]
 
 [[package]]
@@ -3580,7 +3581,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.19.2"
+version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -3588,9 +3589,9 @@ dependencies = [
     { name = "shellingham" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/ca/950278884e2ca20547ff3eb109478c6baf6b8cf219318e6bc4f666fad8e8/typer-0.19.2.tar.gz", hash = "sha256:9ad824308ded0ad06cc716434705f691d4ee0bfd0fb081839d2e426860e7fdca", size = 104755, upload-time = "2025-09-23T09:47:48.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/bf/8825b5929afd84d0dabd606c67cd57b8388cb3ec385f7ef19c5cc2202069/typer-0.21.1.tar.gz", hash = "sha256:ea835607cd752343b6b2b7ce676893e5a0324082268b48f27aa058bdb7d2145d", size = 110371, upload-time = "2026-01-06T11:21:10.989Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/22/35617eee79080a5d071d0f14ad698d325ee6b3bf824fc0467c03b30e7fa8/typer-0.19.2-py3-none-any.whl", hash = "sha256:755e7e19670ffad8283db353267cb81ef252f595aa6834a0d1ca9312d9326cb9", size = 46748, upload-time = "2025-09-23T09:47:46.777Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/d9257dd49ff2ca23ea5f132edf1281a0c4f9de8a762b9ae399b670a59235/typer-0.21.1-py3-none-any.whl", hash = "sha256:7985e89081c636b88d172c2ee0cfe33c253160994d47bdfdc302defd7d1f1d01", size = 47381, upload-time = "2026-01-06T11:21:09.824Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Refresh uv.lock to capture updated dependencies compatible with gdsfactory 9.34.