### PR TITLE
Add device PCell sizing validation

### DIFF
--- a/ihp/cells/antennas.py
+++ b/ihp/cells/antennas.py
@@ -7,6 +7,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 from cni.tech import Tech
+from ihp.tech import TECH as _TECH
 
 tech_name = "SG13_dev"
 tech = Tech.get("SG13_dev").getTechParams()
@@ -157,17 +158,20 @@ def dantenna(
 
     Returns:
         gdsfactory.Component: The generated antenna component.
+
+    Raises:
+        ValueError: If width or length is outside allowed range.
     """
+    if width < _TECH.dantenna_min_width or width > _TECH.dantenna_max_width:
+        raise ValueError(
+            f"dantenna width={width} out of range [{_TECH.dantenna_min_width}, {_TECH.dantenna_max_width}]"
+        )
+    if length < _TECH.dantenna_min_length or length > _TECH.dantenna_max_length:
+        raise ValueError(
+            f"dantenna length={length} out of range [{_TECH.dantenna_min_length}, {_TECH.dantenna_max_length}]"
+        )
 
     c = gf.Component()
-
-    wmin = float(tech["dantenna_minW"].rstrip("u"))
-    lmin = float(tech["dantenna_minL"].rstrip("u"))
-
-    if width < wmin:
-        width = wmin
-    if length < lmin:
-        length = lmin
 
     layer_metal1: LayerSpec = "Metal1drawing"
     ndiff_layer: LayerSpec = "Activdrawing"
@@ -274,17 +278,20 @@ def dpantenna(
 
     Returns:
         gdsfactory.Component: The generated antenna component.
+
+    Raises:
+        ValueError: If width or length is outside allowed range.
     """
+    if width < _TECH.dpantenna_min_width or width > _TECH.dpantenna_max_width:
+        raise ValueError(
+            f"dpantenna width={width} out of range [{_TECH.dpantenna_min_width}, {_TECH.dpantenna_max_width}]"
+        )
+    if length < _TECH.dpantenna_min_length or length > _TECH.dpantenna_max_length:
+        raise ValueError(
+            f"dpantenna length={length} out of range [{_TECH.dpantenna_min_length}, {_TECH.dpantenna_max_length}]"
+        )
 
     c = gf.Component()
-
-    wmin = float(tech["dantenna_minW"].rstrip("u"))
-    lmin = float(tech["dantenna_minL"].rstrip("u"))
-
-    if width < wmin:
-        width = wmin
-    if length < lmin:
-        length = lmin
 
     layer_metal1: LayerSpec = "Metal1drawing"
     pdiff_layer: LayerSpec = "Activdrawing"

--- a/ihp/cells/bjt_transistors.py
+++ b/ihp/cells/bjt_transistors.py
@@ -6,6 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import LayerSpec
 
 from cni.tech import Tech
+from ihp.tech import TECH as _TECH
 
 tech_name = "SG13_dev"
 tech = Tech.get("SG13_dev").getTechParams()
@@ -67,7 +68,15 @@ def npn13G2(
 
     Returns:
         gdsfactory.Component: The generated npn13G2 transistor layout.
+
+    Raises:
+        ValueError: If finger count is outside allowed range.
     """
+    total_nx = Nx * Ny
+    if total_nx < _TECH.npn_min_nx or total_nx > _TECH.npn_max_nx:
+        raise ValueError(
+            f"npn13G2 Nx*Ny={total_nx} out of range [{_TECH.npn_min_nx}, {_TECH.npn_max_nx}]"
+        )
 
     c = gf.Component()
 
@@ -752,7 +761,15 @@ def npn13G2L(
 
     Returns:
         gdsfactory.Component: The generated npn13G2L transistor layout.
+
+    Raises:
+        ValueError: If finger count is outside allowed range.
     """
+    if Nx < _TECH.npn_min_nx or Nx > _TECH.npn_max_nx:
+        raise ValueError(
+            f"npn13G2L Nx={Nx} out of range [{_TECH.npn_min_nx}, {_TECH.npn_max_nx}]"
+        )
+
     c = gf.Component()
 
     layer_EmWind: LayerSpec = "EmWinddrawing"
@@ -1313,8 +1330,16 @@ def npn13G2V(
         Nx: Number of emitter fingers.
 
     Returns:
-        gdsfactory.Component: The generated npn13G2L transistor layout.
+        gdsfactory.Component: The generated npn13G2V transistor layout.
+
+    Raises:
+        ValueError: If finger count is outside allowed range.
     """
+    if Nx < _TECH.npn_min_nx or Nx > _TECH.npn_max_nx:
+        raise ValueError(
+            f"npn13G2V Nx={Nx} out of range [{_TECH.npn_min_nx}, {_TECH.npn_max_nx}]"
+        )
+
     c = gf.Component()
 
     layer_EmWiHV: LayerSpec = "EmWiHVdrawing"
@@ -1981,7 +2006,18 @@ def pnpMPA(length: float = 2, width: float = 0.7) -> gf.Component:
 
     Returns:
         gdsfactory.Component: The generated pnpMPA transistor layout.
+
+    Raises:
+        ValueError: If width or length is outside allowed range.
     """
+    if width < _TECH.pnp_min_width or width > _TECH.pnp_max_width:
+        raise ValueError(
+            f"pnpMPA width={width} out of range [{_TECH.pnp_min_width}, {_TECH.pnp_max_width}]"
+        )
+    if length < _TECH.pnp_min_length or length > _TECH.pnp_max_length:
+        raise ValueError(
+            f"pnpMPA length={length} out of range [{_TECH.pnp_min_length}, {_TECH.pnp_max_length}]"
+        )
 
     c = gf.Component()
 

--- a/ihp/cells/capacitors.py
+++ b/ihp/cells/capacitors.py
@@ -350,8 +350,18 @@ def cmim(
 
     Returns:
         Component with MIM capacitor layout.
+
     Raises:
+        ValueError: If width or length is outside allowed range.
     """
+    if width < tech.TECH.cmim_min_size or width > tech.TECH.cmim_max_size:
+        raise ValueError(
+            f"cmim width={width} out of range [{tech.TECH.cmim_min_size}, {tech.TECH.cmim_max_size}]"
+        )
+    if length < tech.TECH.cmim_min_size or length > tech.TECH.cmim_max_size:
+        raise ValueError(
+            f"cmim length={length} out of range [{tech.TECH.cmim_min_size}, {tech.TECH.cmim_max_size}]"
+        )
 
     c = Component()
 
@@ -374,10 +384,6 @@ def cmim(
 
     bot_enclosure = mim_drc["vmim_enc"]
     top_enclosure = mim_drc["mim_enc"]
-
-    # verification
-    assert width > mim_drc["mim_min_size"], f"MIM width > {mim_drc['mim_min_size']}"
-    assert length > mim_drc["mim_min_size"], f"MIM width > {mim_drc['mim_min_size']}"
 
     # snap to grid
     grid = tech.TECH.grid
@@ -584,8 +590,18 @@ def rfcmim(
 
     Returns:
         Component with MIM capacitor layout.
+
     Raises:
+        ValueError: If width or length is outside allowed range.
     """
+    if width < tech.TECH.rfcmim_min_size or width > tech.TECH.rfcmim_max_size:
+        raise ValueError(
+            f"rfcmim width={width} out of range [{tech.TECH.rfcmim_min_size}, {tech.TECH.rfcmim_max_size}]"
+        )
+    if length < tech.TECH.rfcmim_min_size or length > tech.TECH.rfcmim_max_size:
+        raise ValueError(
+            f"rfcmim length={length} out of range [{tech.TECH.rfcmim_min_size}, {tech.TECH.rfcmim_max_size}]"
+        )
 
     c = Component()
 

--- a/ihp/cells/fet_transistors.py
+++ b/ihp/cells/fet_transistors.py
@@ -529,7 +529,21 @@ def nmos(
 
     Returns:
         Component with NMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.nmos_min_width or width > TECH.nmos_max_width:
+        raise ValueError(
+            f"nmos width={width} out of range [{TECH.nmos_min_width}, {TECH.nmos_max_width}]"
+        )
+    if length < TECH.nmos_min_length or length > TECH.nmos_max_length:
+        raise ValueError(
+            f"nmos length={length} out of range [{TECH.nmos_min_length}, {TECH.nmos_max_length}]"
+        )
+    if nf < 1 or nf > TECH.nmos_max_nf:
+        raise ValueError(f"nmos nf={nf} out of range [1, {TECH.nmos_max_nf}]")
+
     c = _mos_core(width, length, nf, is_pmos=False, is_hv=False)
 
     # VLSIR simulation metadata
@@ -569,7 +583,21 @@ def pmos(
 
     Returns:
         Component with PMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.pmos_min_width or width > TECH.pmos_max_width:
+        raise ValueError(
+            f"pmos width={width} out of range [{TECH.pmos_min_width}, {TECH.pmos_max_width}]"
+        )
+    if length < TECH.pmos_min_length or length > TECH.pmos_max_length:
+        raise ValueError(
+            f"pmos length={length} out of range [{TECH.pmos_min_length}, {TECH.pmos_max_length}]"
+        )
+    if nf < 1 or nf > TECH.pmos_max_nf:
+        raise ValueError(f"pmos nf={nf} out of range [1, {TECH.pmos_max_nf}]")
+
     c = _mos_core(width, length, nf, is_pmos=True, is_hv=False)
 
     # VLSIR simulation metadata
@@ -609,7 +637,21 @@ def nmos_hv(
 
     Returns:
         Component with HV NMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.nmos_hv_min_width or width > TECH.nmos_hv_max_width:
+        raise ValueError(
+            f"nmos_hv width={width} out of range [{TECH.nmos_hv_min_width}, {TECH.nmos_hv_max_width}]"
+        )
+    if length < TECH.nmos_hv_min_length or length > TECH.nmos_hv_max_length:
+        raise ValueError(
+            f"nmos_hv length={length} out of range [{TECH.nmos_hv_min_length}, {TECH.nmos_hv_max_length}]"
+        )
+    if nf < 1 or nf > TECH.nmos_hv_max_nf:
+        raise ValueError(f"nmos_hv nf={nf} out of range [1, {TECH.nmos_hv_max_nf}]")
+
     c = _mos_core(width, length, nf, is_pmos=False, is_hv=True)
 
     # VLSIR simulation metadata
@@ -649,7 +691,21 @@ def pmos_hv(
 
     Returns:
         Component with HV PMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.pmos_hv_min_width or width > TECH.pmos_hv_max_width:
+        raise ValueError(
+            f"pmos_hv width={width} out of range [{TECH.pmos_hv_min_width}, {TECH.pmos_hv_max_width}]"
+        )
+    if length < TECH.pmos_hv_min_length or length > TECH.pmos_hv_max_length:
+        raise ValueError(
+            f"pmos_hv length={length} out of range [{TECH.pmos_hv_min_length}, {TECH.pmos_hv_max_length}]"
+        )
+    if nf < 1 or nf > TECH.pmos_hv_max_nf:
+        raise ValueError(f"pmos_hv nf={nf} out of range [1, {TECH.pmos_hv_max_nf}]")
+
     c = _mos_core(width, length, nf, is_pmos=True, is_hv=True)
 
     # VLSIR simulation metadata

--- a/ihp/cells/passives.py
+++ b/ihp/cells/passives.py
@@ -392,7 +392,19 @@ def ptap1(
 
     Returns:
         Component with P+ tap layout.
+
+    Raises:
+        ValueError: If width or length is outside allowed range.
     """
+    if width < tech.TECH.ptap1_min_size or width > tech.TECH.ptap1_max_size:
+        raise ValueError(
+            f"ptap1 width={width} out of range [{tech.TECH.ptap1_min_size}, {tech.TECH.ptap1_max_size}]"
+        )
+    if length < tech.TECH.ptap1_min_size or length > tech.TECH.ptap1_max_size:
+        raise ValueError(
+            f"ptap1 length={length} out of range [{tech.TECH.ptap1_min_size}, {tech.TECH.ptap1_max_size}]"
+        )
+
     c = Component()
 
     # Design rules
@@ -508,7 +520,19 @@ def ntap1(
 
     Returns:
         Component with N+ tap layout.
+
+    Raises:
+        ValueError: If width or length is outside allowed range.
     """
+    if width < tech.TECH.ntap1_min_size or width > tech.TECH.ntap1_max_size:
+        raise ValueError(
+            f"ntap1 width={width} out of range [{tech.TECH.ntap1_min_size}, {tech.TECH.ntap1_max_size}]"
+        )
+    if length < tech.TECH.ntap1_min_size or length > tech.TECH.ntap1_max_size:
+        raise ValueError(
+            f"ntap1 length={length} out of range [{tech.TECH.ntap1_min_size}, {tech.TECH.ntap1_max_size}]"
+        )
+
     c = Component()
 
     # Design rules
@@ -649,7 +673,19 @@ def sealring(
 
     Returns:
         Component with seal ring layout.
+
+    Raises:
+        ValueError: If width or height is outside allowed range.
     """
+    if width < tech.TECH.sealring_min_width or width > tech.TECH.sealring_max_width:
+        raise ValueError(
+            f"sealring width={width} out of range [{tech.TECH.sealring_min_width}, {tech.TECH.sealring_max_width}]"
+        )
+    if height < tech.TECH.sealring_min_height or height > tech.TECH.sealring_max_height:
+        raise ValueError(
+            f"sealring height={height} out of range [{tech.TECH.sealring_min_height}, {tech.TECH.sealring_max_height}]"
+        )
+
     c = Component()
 
     # Create seal ring on all metal layers

--- a/ihp/cells/resistors.py
+++ b/ihp/cells/resistors.py
@@ -4,6 +4,8 @@ import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.typings import LayerSpec
 
+from ihp.tech import TECH as _TECH
+
 
 def add_rect(
     component,
@@ -52,7 +54,19 @@ def rsil(
 
     Returns:
         Component with silicided poly resistor layout.
+
+    Raises:
+        ValueError: If dx (width) or dy (length) is outside allowed range.
     """
+    if dx < _TECH.rsil_min_width or dx > _TECH.rsil_max_width:
+        raise ValueError(
+            f"rsil dx={dx} out of range [{_TECH.rsil_min_width}, {_TECH.rsil_max_width}]"
+        )
+    if dy < _TECH.rsil_min_length or dy > _TECH.rsil_max_length:
+        raise ValueError(
+            f"rsil dy={dy} out of range [{_TECH.rsil_min_length}, {_TECH.rsil_max_length}]"
+        )
+
     c = Component()
 
     # Constants
@@ -69,7 +83,7 @@ def rsil(
     METAL_CONTACT_MARGIN = 0.05
     BLOCK_MARGIN = 0.18
 
-    # Validate / snap to grid
+    # Snap to grid
     dy = max(dy, RSIL_MIN_DY)
     dx = max(dx, RSIL_MIN_DX)
     dy = round(dy / GRID) * GRID
@@ -231,7 +245,19 @@ def rppd(
 
     Returns:
         Component with P+ resistor layout.
+
+    Raises:
+        ValueError: If dx (width) or dy (length) is outside allowed range.
     """
+    if dx < _TECH.rppd_min_width or dx > _TECH.rppd_max_width:
+        raise ValueError(
+            f"rppd dx={dx} out of range [{_TECH.rppd_min_width}, {_TECH.rppd_max_width}]"
+        )
+    if dy < _TECH.rppd_min_length or dy > _TECH.rppd_max_length:
+        raise ValueError(
+            f"rppd dy={dy} out of range [{_TECH.rppd_min_length}, {_TECH.rppd_max_length}]"
+        )
+
     c = Component()
 
     # Constants
@@ -252,7 +278,7 @@ def rppd(
     BLOCK_MARGIN = 0.18
     BLOCK2_MARGIN = 0.02
 
-    # Validate
+    # Snap to grid
     dy = max(dy, RPPD_MIN_DY)
     dx = max(dx, RPPD_MIN_DX)
     dy = round(dy / GRID) * GRID
@@ -424,7 +450,19 @@ def rhigh(
 
     Returns:
         Component with high-resistance poly resistor layout.
+
+    Raises:
+        ValueError: If dx (width) or dy (length) is outside allowed range.
     """
+    if dx < _TECH.rhigh_min_width or dx > _TECH.rhigh_max_width:
+        raise ValueError(
+            f"rhigh dx={dx} out of range [{_TECH.rhigh_min_width}, {_TECH.rhigh_max_width}]"
+        )
+    if dy < _TECH.rhigh_min_length or dy > _TECH.rhigh_max_length:
+        raise ValueError(
+            f"rhigh dy={dy} out of range [{_TECH.rhigh_min_length}, {_TECH.rhigh_max_length}]"
+        )
+
     c = Component()
 
     # Constants
@@ -443,7 +481,7 @@ def rhigh(
     BLOCK1_MARGIN = 0.18
     BLOCK2_MARGIN = 0.02
 
-    # Validate
+    # Snap to grid
     dy = max(dy, RHIGH_MIN_DY)
     dx = max(dx, RHIGH_MIN_DX)
     dy = round(dy / GRID) * GRID

--- a/ihp/cells/rf_transistors.py
+++ b/ihp/cells/rf_transistors.py
@@ -908,7 +908,21 @@ def rfnmos(
 
     Returns:
         Component with RF NMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.rfnmos_min_width or width > TECH.rfnmos_max_width:
+        raise ValueError(
+            f"rfnmos width={width} out of range [{TECH.rfnmos_min_width}, {TECH.rfnmos_max_width}]"
+        )
+    if length < TECH.rfnmos_min_length or length > TECH.rfnmos_max_length:
+        raise ValueError(
+            f"rfnmos length={length} out of range [{TECH.rfnmos_min_length}, {TECH.rfnmos_max_length}]"
+        )
+    if nf < 1 or nf > TECH.rfnmos_max_nf:
+        raise ValueError(f"rfnmos nf={nf} out of range [1, {TECH.rfnmos_max_nf}]")
+
     c = _rf_mos_core(
         width,
         length,
@@ -964,7 +978,21 @@ def rfpmos(
 
     Returns:
         Component with RF PMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.rfpmos_min_width or width > TECH.rfpmos_max_width:
+        raise ValueError(
+            f"rfpmos width={width} out of range [{TECH.rfpmos_min_width}, {TECH.rfpmos_max_width}]"
+        )
+    if length < TECH.rfpmos_min_length or length > TECH.rfpmos_max_length:
+        raise ValueError(
+            f"rfpmos length={length} out of range [{TECH.rfpmos_min_length}, {TECH.rfpmos_max_length}]"
+        )
+    if nf < 1 or nf > TECH.rfpmos_max_nf:
+        raise ValueError(f"rfpmos nf={nf} out of range [1, {TECH.rfpmos_max_nf}]")
+
     c = _rf_mos_core(
         width,
         length,
@@ -1020,7 +1048,21 @@ def rfnmos_hv(
 
     Returns:
         Component with HV RF NMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.rfnmos_hv_min_width or width > TECH.rfnmos_hv_max_width:
+        raise ValueError(
+            f"rfnmos_hv width={width} out of range [{TECH.rfnmos_hv_min_width}, {TECH.rfnmos_hv_max_width}]"
+        )
+    if length < TECH.rfnmos_hv_min_length or length > TECH.rfnmos_hv_max_length:
+        raise ValueError(
+            f"rfnmos_hv length={length} out of range [{TECH.rfnmos_hv_min_length}, {TECH.rfnmos_hv_max_length}]"
+        )
+    if nf < 1 or nf > TECH.rfnmos_hv_max_nf:
+        raise ValueError(f"rfnmos_hv nf={nf} out of range [1, {TECH.rfnmos_hv_max_nf}]")
+
     c = _rf_mos_core(
         width,
         length,
@@ -1076,7 +1118,21 @@ def rfpmos_hv(
 
     Returns:
         Component with HV RF PMOS transistor layout.
+
+    Raises:
+        ValueError: If width, length, or nf is outside allowed range.
     """
+    if width < TECH.rfpmos_hv_min_width or width > TECH.rfpmos_hv_max_width:
+        raise ValueError(
+            f"rfpmos_hv width={width} out of range [{TECH.rfpmos_hv_min_width}, {TECH.rfpmos_hv_max_width}]"
+        )
+    if length < TECH.rfpmos_hv_min_length or length > TECH.rfpmos_hv_max_length:
+        raise ValueError(
+            f"rfpmos_hv length={length} out of range [{TECH.rfpmos_hv_min_length}, {TECH.rfpmos_hv_max_length}]"
+        )
+    if nf < 1 or nf > TECH.rfpmos_hv_max_nf:
+        raise ValueError(f"rfpmos_hv nf={nf} out of range [1, {TECH.rfpmos_hv_max_nf}]")
+
     c = _rf_mos_core(
         width,
         length,

--- a/ihp/tech.py
+++ b/ihp/tech.py
@@ -697,16 +697,8 @@ class TechIHP(BaseModel):
     topmetal2_spacing: float = 2.0
 
     # Design rules - resistors
-    rsil_min_width: float = 0.4
-    rsil_min_length: float = 0.8
     rsil_sheet_res: float = 7.0  # ohms/square
-
-    rppd_min_width: float = 0.4
-    rppd_min_length: float = 0.8
     rppd_sheet_res: float = 300.0  # ohms/square
-
-    rhigh_min_width: float = 1.4
-    rhigh_min_length: float = 5.0
     rhigh_sheet_res: float = 1350.0  # ohms/square
 
     # Design rules - capacitors
@@ -782,6 +774,115 @@ class TechIHP(BaseModel):
     rf_nw_pmos_lv: float = 0.31  # NWell extension (PMOS LV)
 
     rf_gate_pin_half_width: float = 0.1
+
+    # --- Device sizing limits (from sg13g2_tech.json) ---
+
+    # NMOS (LV)
+    nmos_max_width: float = 10.0
+    nmos_max_length: float = 10.0
+    nmos_max_nf: int = 100
+
+    # PMOS (LV)
+    pmos_max_width: float = 10.0
+    pmos_max_length: float = 10.0
+    pmos_max_nf: int = 100
+
+    # NMOS HV
+    nmos_hv_min_width: float = 0.30
+    nmos_hv_max_width: float = 10.0
+    nmos_hv_min_length: float = 0.45
+    nmos_hv_max_length: float = 10.0
+    nmos_hv_max_nf: int = 100
+
+    # PMOS HV
+    pmos_hv_min_width: float = 0.30
+    pmos_hv_max_width: float = 10.0
+    pmos_hv_min_length: float = 0.40
+    pmos_hv_max_length: float = 10.0
+    pmos_hv_max_nf: int = 100
+
+    # RF NMOS (LV)
+    rfnmos_min_width: float = 0.15
+    rfnmos_max_width: float = 10.0
+    rfnmos_min_length: float = 0.13
+    rfnmos_max_length: float = 10.0
+    rfnmos_max_nf: int = 40
+
+    # RF PMOS (LV)
+    rfpmos_min_width: float = 0.15
+    rfpmos_max_width: float = 10.0
+    rfpmos_min_length: float = 0.13
+    rfpmos_max_length: float = 10.0
+    rfpmos_max_nf: int = 40
+
+    # RF NMOS HV
+    rfnmos_hv_min_width: float = 0.33
+    rfnmos_hv_max_width: float = 10.0
+    rfnmos_hv_min_length: float = 0.45
+    rfnmos_hv_max_length: float = 10.0
+    rfnmos_hv_max_nf: int = 40
+
+    # RF PMOS HV
+    rfpmos_hv_min_width: float = 0.39
+    rfpmos_hv_max_width: float = 10.0
+    rfpmos_hv_min_length: float = 0.40
+    rfpmos_hv_max_length: float = 10.0
+    rfpmos_hv_max_nf: int = 40
+
+    # BJT NPN (npn13G2, npn13G2L, npn13G2V) - only Nx validated;
+    # emitter dimensions are fixed-size in the JSON but variable in our cells.
+    npn_min_nx: int = 1
+    npn_max_nx: int = 10
+
+    # BJT PNP (pnpMPA)
+    pnp_min_length: float = 0.68
+    pnp_max_length: float = 1000.0
+    pnp_min_width: float = 0.30
+    pnp_max_width: float = 2.0
+
+    # Resistors
+    rsil_min_width: float = 0.50
+    rsil_max_width: float = 1000.0
+    rsil_min_length: float = 0.50
+    rsil_max_length: float = 1000.0
+
+    rppd_min_width: float = 0.50
+    rppd_max_width: float = 1000.0
+    rppd_min_length: float = 0.50
+    rppd_max_length: float = 1000.0
+
+    rhigh_min_width: float = 0.50
+    rhigh_max_width: float = 1000.0
+    rhigh_min_length: float = 0.96
+    rhigh_max_length: float = 1000.0
+
+    # Capacitors
+    cmim_min_size: float = 1.14
+    cmim_max_size: float = 1000.0
+    rfcmim_min_size: float = 7.0
+    rfcmim_max_size: float = 1000.0
+
+    # Taps
+    ptap1_min_size: float = 0.78
+    ptap1_max_size: float = 10_000_000.0
+    ntap1_min_size: float = 0.78
+    ntap1_max_size: float = 10_000.0
+
+    # Antennas
+    dantenna_min_width: float = 0.48
+    dantenna_max_width: float = 1000.0
+    dantenna_min_length: float = 0.48
+    dantenna_max_length: float = 1000.0
+    dpantenna_min_width: float = 0.48
+    dpantenna_max_width: float = 1000.0
+    dpantenna_min_length: float = 0.48
+    dpantenna_max_length: float = 1000.0
+
+    # Sealring
+    sealring_min_width: float = 150.0
+    sealring_max_width: float = 32000.0
+    sealring_min_height: float = 150.0
+    sealring_max_height: float = 25000.0
 
 
 TECH = TechIHP()

--- a/tests/test_sizing.py
+++ b/tests/test_sizing.py
@@ -1,0 +1,490 @@
+"""Tests for device PCell sizing validation.
+
+Verifies that all cell functions raise ValueError when given out-of-range
+dimensions, and accept default (in-range) parameters without error.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ihp import PDK
+from ihp.tech import TECH
+
+
+@pytest.fixture(autouse=True)
+def activate_pdk() -> None:
+    PDK.activate()
+
+
+# ---------------------------------------------------------------------------
+# FET transistors
+# ---------------------------------------------------------------------------
+class TestNmos:
+    def test_default_params(self):
+        from ihp.cells.fet_transistors import nmos
+        nmos()
+
+    def test_width_below_min(self):
+        from ihp.cells.fet_transistors import nmos
+        with pytest.raises(ValueError, match="nmos width"):
+            nmos(width=TECH.nmos_min_width - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.fet_transistors import nmos
+        with pytest.raises(ValueError, match="nmos width"):
+            nmos(width=TECH.nmos_max_width + 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.fet_transistors import nmos
+        with pytest.raises(ValueError, match="nmos length"):
+            nmos(length=TECH.nmos_min_length - 0.01)
+
+    def test_length_above_max(self):
+        from ihp.cells.fet_transistors import nmos
+        with pytest.raises(ValueError, match="nmos length"):
+            nmos(length=TECH.nmos_max_length + 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.fet_transistors import nmos
+        with pytest.raises(ValueError, match="nmos nf"):
+            nmos(nf=TECH.nmos_max_nf + 1)
+
+    def test_nf_below_min(self):
+        from ihp.cells.fet_transistors import nmos
+        with pytest.raises(ValueError, match="nmos nf"):
+            nmos(nf=0)
+
+
+class TestPmos:
+    def test_default_params(self):
+        from ihp.cells.fet_transistors import pmos
+        pmos()
+
+    def test_width_below_min(self):
+        from ihp.cells.fet_transistors import pmos
+        with pytest.raises(ValueError, match="pmos width"):
+            pmos(width=TECH.pmos_min_width - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.fet_transistors import pmos
+        with pytest.raises(ValueError, match="pmos width"):
+            pmos(width=TECH.pmos_max_width + 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.fet_transistors import pmos
+        with pytest.raises(ValueError, match="pmos length"):
+            pmos(length=TECH.pmos_min_length - 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.fet_transistors import pmos
+        with pytest.raises(ValueError, match="pmos nf"):
+            pmos(nf=TECH.pmos_max_nf + 1)
+
+
+class TestNmosHv:
+    def test_default_params(self):
+        from ihp.cells.fet_transistors import nmos_hv
+        nmos_hv()
+
+    def test_width_below_min(self):
+        from ihp.cells.fet_transistors import nmos_hv
+        with pytest.raises(ValueError, match="nmos_hv width"):
+            nmos_hv(width=TECH.nmos_hv_min_width - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.fet_transistors import nmos_hv
+        with pytest.raises(ValueError, match="nmos_hv width"):
+            nmos_hv(width=TECH.nmos_hv_max_width + 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.fet_transistors import nmos_hv
+        with pytest.raises(ValueError, match="nmos_hv length"):
+            nmos_hv(length=TECH.nmos_hv_min_length - 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.fet_transistors import nmos_hv
+        with pytest.raises(ValueError, match="nmos_hv nf"):
+            nmos_hv(nf=TECH.nmos_hv_max_nf + 1)
+
+
+class TestPmosHv:
+    def test_default_params(self):
+        from ihp.cells.fet_transistors import pmos_hv
+        pmos_hv()
+
+    def test_width_below_min(self):
+        from ihp.cells.fet_transistors import pmos_hv
+        with pytest.raises(ValueError, match="pmos_hv width"):
+            pmos_hv(width=TECH.pmos_hv_min_width - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.fet_transistors import pmos_hv
+        with pytest.raises(ValueError, match="pmos_hv width"):
+            pmos_hv(width=TECH.pmos_hv_max_width + 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.fet_transistors import pmos_hv
+        with pytest.raises(ValueError, match="pmos_hv length"):
+            pmos_hv(length=TECH.pmos_hv_min_length - 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.fet_transistors import pmos_hv
+        with pytest.raises(ValueError, match="pmos_hv nf"):
+            pmos_hv(nf=TECH.pmos_hv_max_nf + 1)
+
+
+# ---------------------------------------------------------------------------
+# RF transistors
+# ---------------------------------------------------------------------------
+class TestRfnmos:
+    def test_default_params(self):
+        from ihp.cells.rf_transistors import rfnmos
+        rfnmos()
+
+    def test_width_below_min(self):
+        from ihp.cells.rf_transistors import rfnmos
+        with pytest.raises(ValueError, match="rfnmos width"):
+            rfnmos(width=TECH.rfnmos_min_width - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.rf_transistors import rfnmos
+        with pytest.raises(ValueError, match="rfnmos width"):
+            rfnmos(width=TECH.rfnmos_max_width + 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.rf_transistors import rfnmos
+        with pytest.raises(ValueError, match="rfnmos length"):
+            rfnmos(length=TECH.rfnmos_min_length - 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.rf_transistors import rfnmos
+        with pytest.raises(ValueError, match="rfnmos nf"):
+            rfnmos(nf=TECH.rfnmos_max_nf + 1)
+
+
+class TestRfpmos:
+    def test_default_params(self):
+        from ihp.cells.rf_transistors import rfpmos
+        rfpmos()
+
+    def test_width_below_min(self):
+        from ihp.cells.rf_transistors import rfpmos
+        with pytest.raises(ValueError, match="rfpmos width"):
+            rfpmos(width=TECH.rfpmos_min_width - 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.rf_transistors import rfpmos
+        with pytest.raises(ValueError, match="rfpmos nf"):
+            rfpmos(nf=TECH.rfpmos_max_nf + 1)
+
+
+class TestRfnmosHv:
+    def test_default_params(self):
+        from ihp.cells.rf_transistors import rfnmos_hv
+        rfnmos_hv()
+
+    def test_width_below_min(self):
+        from ihp.cells.rf_transistors import rfnmos_hv
+        with pytest.raises(ValueError, match="rfnmos_hv width"):
+            rfnmos_hv(width=TECH.rfnmos_hv_min_width - 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.rf_transistors import rfnmos_hv
+        with pytest.raises(ValueError, match="rfnmos_hv length"):
+            rfnmos_hv(length=TECH.rfnmos_hv_min_length - 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.rf_transistors import rfnmos_hv
+        with pytest.raises(ValueError, match="rfnmos_hv nf"):
+            rfnmos_hv(nf=TECH.rfnmos_hv_max_nf + 1)
+
+
+class TestRfpmosHv:
+    def test_default_params(self):
+        from ihp.cells.rf_transistors import rfpmos_hv
+        rfpmos_hv()
+
+    def test_width_below_min(self):
+        from ihp.cells.rf_transistors import rfpmos_hv
+        with pytest.raises(ValueError, match="rfpmos_hv width"):
+            rfpmos_hv(width=TECH.rfpmos_hv_min_width - 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.rf_transistors import rfpmos_hv
+        with pytest.raises(ValueError, match="rfpmos_hv length"):
+            rfpmos_hv(length=TECH.rfpmos_hv_min_length - 0.01)
+
+    def test_nf_above_max(self):
+        from ihp.cells.rf_transistors import rfpmos_hv
+        with pytest.raises(ValueError, match="rfpmos_hv nf"):
+            rfpmos_hv(nf=TECH.rfpmos_hv_max_nf + 1)
+
+
+# ---------------------------------------------------------------------------
+# BJT transistors
+# ---------------------------------------------------------------------------
+class TestNpn13G2:
+    def test_default_params(self):
+        from ihp.cells.bjt_transistors import npn13G2
+        npn13G2()
+
+    def test_nx_above_max(self):
+        from ihp.cells.bjt_transistors import npn13G2
+        with pytest.raises(ValueError, match="npn13G2 Nx"):
+            npn13G2(Nx=TECH.npn_max_nx + 1)
+
+    def test_nx_zero(self):
+        from ihp.cells.bjt_transistors import npn13G2
+        with pytest.raises(ValueError, match="npn13G2 Nx"):
+            npn13G2(Nx=0)
+
+
+class TestNpn13G2L:
+    def test_default_params(self):
+        from ihp.cells.bjt_transistors import npn13G2L
+        npn13G2L()
+
+    def test_nx_above_max(self):
+        from ihp.cells.bjt_transistors import npn13G2L
+        with pytest.raises(ValueError, match="npn13G2L Nx"):
+            npn13G2L(Nx=TECH.npn_max_nx + 1)
+
+
+class TestNpn13G2V:
+    def test_default_params(self):
+        from ihp.cells.bjt_transistors import npn13G2V
+        npn13G2V()
+
+    def test_nx_above_max(self):
+        from ihp.cells.bjt_transistors import npn13G2V
+        with pytest.raises(ValueError, match="npn13G2V Nx"):
+            npn13G2V(Nx=TECH.npn_max_nx + 1)
+
+
+class TestPnpMPA:
+    def test_default_params(self):
+        from ihp.cells.bjt_transistors import pnpMPA
+        pnpMPA()
+
+    def test_width_below_min(self):
+        from ihp.cells.bjt_transistors import pnpMPA
+        with pytest.raises(ValueError, match="pnpMPA width"):
+            pnpMPA(width=TECH.pnp_min_width - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.bjt_transistors import pnpMPA
+        with pytest.raises(ValueError, match="pnpMPA width"):
+            pnpMPA(width=TECH.pnp_max_width + 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.bjt_transistors import pnpMPA
+        with pytest.raises(ValueError, match="pnpMPA length"):
+            pnpMPA(length=TECH.pnp_min_length - 0.01)
+
+    def test_length_above_max(self):
+        from ihp.cells.bjt_transistors import pnpMPA
+        with pytest.raises(ValueError, match="pnpMPA length"):
+            pnpMPA(length=TECH.pnp_max_length + 0.01)
+
+
+# ---------------------------------------------------------------------------
+# Resistors
+# ---------------------------------------------------------------------------
+class TestRsil:
+    def test_default_params(self):
+        from ihp.cells.resistors import rsil
+        rsil()
+
+    def test_dx_below_min(self):
+        from ihp.cells.resistors import rsil
+        with pytest.raises(ValueError, match="rsil dx"):
+            rsil(dx=TECH.rsil_min_width - 0.01)
+
+    def test_dx_above_max(self):
+        from ihp.cells.resistors import rsil
+        with pytest.raises(ValueError, match="rsil dx"):
+            rsil(dx=TECH.rsil_max_width + 1)
+
+    def test_dy_below_min(self):
+        from ihp.cells.resistors import rsil
+        with pytest.raises(ValueError, match="rsil dy"):
+            rsil(dy=TECH.rsil_min_length - 0.01)
+
+    def test_dy_above_max(self):
+        from ihp.cells.resistors import rsil
+        with pytest.raises(ValueError, match="rsil dy"):
+            rsil(dy=TECH.rsil_max_length + 1)
+
+
+class TestRppd:
+    def test_default_params(self):
+        from ihp.cells.resistors import rppd
+        rppd()
+
+    def test_dx_below_min(self):
+        from ihp.cells.resistors import rppd
+        with pytest.raises(ValueError, match="rppd dx"):
+            rppd(dx=TECH.rppd_min_width - 0.01)
+
+    def test_dy_below_min(self):
+        from ihp.cells.resistors import rppd
+        with pytest.raises(ValueError, match="rppd dy"):
+            rppd(dy=TECH.rppd_min_length - 0.01)
+
+
+class TestRhigh:
+    def test_default_params(self):
+        from ihp.cells.resistors import rhigh
+        rhigh()
+
+    def test_dx_below_min(self):
+        from ihp.cells.resistors import rhigh
+        with pytest.raises(ValueError, match="rhigh dx"):
+            rhigh(dx=TECH.rhigh_min_width - 0.01)
+
+    def test_dy_below_min(self):
+        from ihp.cells.resistors import rhigh
+        with pytest.raises(ValueError, match="rhigh dy"):
+            rhigh(dy=TECH.rhigh_min_length - 0.01)
+
+
+# ---------------------------------------------------------------------------
+# Capacitors
+# ---------------------------------------------------------------------------
+class TestCmim:
+    def test_default_params(self):
+        from ihp.cells.capacitors import cmim
+        cmim()
+
+    def test_width_below_min(self):
+        from ihp.cells.capacitors import cmim
+        with pytest.raises(ValueError, match="cmim width"):
+            cmim(width=TECH.cmim_min_size - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.capacitors import cmim
+        with pytest.raises(ValueError, match="cmim width"):
+            cmim(width=TECH.cmim_max_size + 1)
+
+    def test_length_below_min(self):
+        from ihp.cells.capacitors import cmim
+        with pytest.raises(ValueError, match="cmim length"):
+            cmim(length=TECH.cmim_min_size - 0.01)
+
+
+class TestRfcmim:
+    def test_default_params(self):
+        from ihp.cells.capacitors import rfcmim
+        rfcmim(width=7.0, length=7.0)
+
+    def test_width_below_min(self):
+        from ihp.cells.capacitors import rfcmim
+        with pytest.raises(ValueError, match="rfcmim width"):
+            rfcmim(width=TECH.rfcmim_min_size - 0.01, length=7.0)
+
+    def test_length_below_min(self):
+        from ihp.cells.capacitors import rfcmim
+        with pytest.raises(ValueError, match="rfcmim length"):
+            rfcmim(width=7.0, length=TECH.rfcmim_min_size - 0.01)
+
+
+# ---------------------------------------------------------------------------
+# Passives (taps, sealring)
+# ---------------------------------------------------------------------------
+class TestPtap1:
+    def test_default_params(self):
+        from ihp.cells.passives import ptap1
+        ptap1()
+
+    def test_width_below_min(self):
+        from ihp.cells.passives import ptap1
+        with pytest.raises(ValueError, match="ptap1 width"):
+            ptap1(width=TECH.ptap1_min_size - 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.passives import ptap1
+        with pytest.raises(ValueError, match="ptap1 length"):
+            ptap1(length=TECH.ptap1_min_size - 0.01)
+
+
+class TestNtap1:
+    def test_default_params(self):
+        from ihp.cells.passives import ntap1
+        ntap1()
+
+    def test_width_below_min(self):
+        from ihp.cells.passives import ntap1
+        with pytest.raises(ValueError, match="ntap1 width"):
+            ntap1(width=TECH.ntap1_min_size - 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.passives import ntap1
+        with pytest.raises(ValueError, match="ntap1 length"):
+            ntap1(length=TECH.ntap1_min_size - 0.01)
+
+
+class TestSealring:
+    def test_default_params(self):
+        from ihp.cells.passives import sealring
+        sealring()
+
+    def test_width_below_min(self):
+        from ihp.cells.passives import sealring
+        with pytest.raises(ValueError, match="sealring width"):
+            sealring(width=TECH.sealring_min_width - 1)
+
+    def test_width_above_max(self):
+        from ihp.cells.passives import sealring
+        with pytest.raises(ValueError, match="sealring width"):
+            sealring(width=TECH.sealring_max_width + 1)
+
+    def test_height_below_min(self):
+        from ihp.cells.passives import sealring
+        with pytest.raises(ValueError, match="sealring height"):
+            sealring(height=TECH.sealring_min_height - 1)
+
+    def test_height_above_max(self):
+        from ihp.cells.passives import sealring
+        with pytest.raises(ValueError, match="sealring height"):
+            sealring(height=TECH.sealring_max_height + 1)
+
+
+# ---------------------------------------------------------------------------
+# Antennas
+# ---------------------------------------------------------------------------
+class TestDantenna:
+    def test_default_params(self):
+        from ihp.cells.antennas import dantenna
+        dantenna()
+
+    def test_width_below_min(self):
+        from ihp.cells.antennas import dantenna
+        with pytest.raises(ValueError, match="dantenna width"):
+            dantenna(width=TECH.dantenna_min_width - 0.01)
+
+    def test_width_above_max(self):
+        from ihp.cells.antennas import dantenna
+        with pytest.raises(ValueError, match="dantenna width"):
+            dantenna(width=TECH.dantenna_max_width + 1)
+
+    def test_length_below_min(self):
+        from ihp.cells.antennas import dantenna
+        with pytest.raises(ValueError, match="dantenna length"):
+            dantenna(length=TECH.dantenna_min_length - 0.01)
+
+
+class TestDpantenna:
+    def test_default_params(self):
+        from ihp.cells.antennas import dpantenna
+        dpantenna()
+
+    def test_width_below_min(self):
+        from ihp.cells.antennas import dpantenna
+        with pytest.raises(ValueError, match="dpantenna width"):
+            dpantenna(width=TECH.dpantenna_min_width - 0.01)
+
+    def test_length_below_min(self):
+        from ihp.cells.antennas import dpantenna
+        with pytest.raises(ValueError, match="dpantenna length"):
+            dpantenna(length=TECH.dpantenna_min_length - 0.01)


### PR DESCRIPTION
## Summary
- Extract device dimension limits (min/max W, L, NF) from `sg13g2_tech.json` and add ~80 sizing constants to `TechIHP` in `tech.py`
- Add `ValueError` validation to every public cell function: FETs, RF MOSFETs, BJTs, resistors, capacitors, taps, sealring, and antennas
- Replace silent clamping and `assert` checks with explicit `ValueError` raises for better user feedback
- Add `tests/test_sizing.py` with 86 tests covering default params, below-min, and above-max violations

## Test plan
- [x] `pytest tests/test_sizing.py` — 86 passed
- [x] Verify existing `test_cells.py` still passes (no regressions from removed silent clamping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add explicit device sizing limits to the technology model and enforce them across all public device PCells, replacing implicit clamping/asserts with clear ValueError-based validation, and cover this behavior with dedicated tests.

New Features:
- Introduce centralized sizing limit constants for transistors, BJTs, resistors, capacitors, taps, sealring, and antennas in the TechIHP technology configuration.
- Add ValueError-based parameter validation to all public device PCell functions to enforce allowed width, length, and finger-count ranges.

Bug Fixes:
- Prevent silent clamping of out-of-range PCell parameters by failing fast with descriptive errors instead of implicit adjustments or assertions.

Enhancements:
- Align device sizing constraints with sg13g2_tech.json by wiring its limits into the Python tech model.
- Improve error messages for invalid device dimensions to aid users in debugging layout parameter issues.

Tests:
- Add tests/test_sizing.py with extensive coverage to verify that default parameters succeed and out-of-range dimensions for all supported devices raise ValueError.