### PR TITLE
fix release drafter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @ThomasPluck
+* @joamatab @ThomasPluck @sheron-lian @thanojo

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,8 +1,11 @@
-name: Release Drafter
+name: Release Drafter and Labels
 on:
   push:
     branches:
       - main
+  pull_request:
+    types: [edited, opened, reopened, synchronize, unlabeled, labeled]
+  workflow_dispatch:
 permissions:
   contents: read
 jobs:


### PR DESCRIPTION
- **Add sheron-lian and thanojo to CODEOWNERS**
- **fix release drafter**

## Summary by Sourcery

Expand and rename the release-drafter workflow and update repository ownership rules.

CI:
- Broaden the release-drafter GitHub Actions workflow to run on main pushes, pull request events, and manual dispatch, and rename it to reflect label handling.

Chores:
- Update CODEOWNERS to include additional code owners.