### PR TITLE
Replace duplicated CI workflows with centralized wrappers

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,7 +4,6 @@ on:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
-
 jobs:
   review:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -4,48 +4,9 @@ on:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
+
 jobs:
-  claude-review:
-    # Run on PR events, or on issue comments that mention @claude
-    if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@claude'))
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@beta
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          trigger_phrase: "@claude"
-          model: "claude-sonnet-4-20250514"
-          timeout_minutes: 30
-          allowed_tools: |
-            Read
-            Glob
-            Grep
-            WebFetch
-            WebSearch
-          custom_instructions: |
-            You are a code reviewer for a GDSFactory PDK (Process Design Kit) repository.
-            This repository contains photonic IC design components and models.
-
-            When reviewing PRs, focus on:
-            1. Code quality and adherence to Python best practices
-            2. Proper use of type hints
-            3. Notebook quality and documentation
-            4. Potential bugs or issues
-            5. Pre-commit hook compliance (ruff formatting, pyright type checking)
-
-            Be constructive and helpful in your feedback. Suggest improvements where appropriate.
-            Reference the AGENTS.md file for AI agent best practices in this repository.
+  review:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -17,14 +17,7 @@ on:
       - transferred
       - milestoned
       - demilestoned
+
 jobs:
-  add-label:
-    runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    steps:
-      - name: Add label
-        run: gh issue edit ${{ github.event.issue.number }} --add-label "pdk"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
+  label:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main

--- a/.github/workflows/issue.yml
+++ b/.github/workflows/issue.yml
@@ -17,7 +17,6 @@ on:
       - transferred
       - milestoned
       - demilestoned
-
 jobs:
   label:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/issue.yml@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,47 +1,10 @@
-name: build docs
+name: Build docs
 on:
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
   workflow_dispatch:
+
 jobs:
-  build-docs:
-    runs-on: ubuntu-latest
-    name: Sphinx docs to gh-pages
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y libglu1-mesa libosmesa6 xvfb
-      - name: Install dependencies
-        run: |
-          make install
-      - name: make docs
-        env:
-          GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
-        run: |
-          make docs
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
-        with:
-          path: "./docs/_build/html/"
-  deploy-docs:
-    needs: build-docs
-    if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  docs:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,7 +2,6 @@ name: Release Drafter
 on:
   push:
     branches: [main]
-
 jobs:
   draft:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,18 +1,8 @@
 name: Release Drafter
 on:
   push:
-    branches:
-      - main
-permissions:
-  contents: read
+    branches: [main]
+
 jobs:
-  update_release_draft:
-    permissions:
-      contents: write
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  draft:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
   push:
     branches: [main]
-
 jobs:
   test:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -1,30 +1,11 @@
 name: Test code
-
 on:
   pull_request:
   push:
-    branches:
-      - main
+    branches: [main]
 
 jobs:
-  pre-commit:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-python@v6
-    - uses: pre-commit/action@v3.0.1
-  test_code:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.12'
-      - name: Install uv
-        uses: astral-sh/setup-uv@v7
-      - name: Install dependencies
-        run: |
-          make install
-      - name: Test with pytest
-        run: make test
+  test:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ version = "0.2.7"
 
 [project.optional-dependencies]
 dev = [
+  "gdsfactoryplus",
   "pytest",
   "pytest-cov",
   "pytest_regressions",


### PR DESCRIPTION
## Summary
- Replace inline CI workflow implementations with thin wrappers delegating to `doplaydo/pdk-ci-workflow` reusable workflows
- Affected workflows: `test_code.yml`, `release-drafter.yml`, `issue.yml`, `claude-pr-review.yml`, `pages.yml`
- Reduces duplication and ensures consistent CI/CD across all PDKs

## Test plan
- [ ] Verify `test_code.yml` workflow triggers and passes on a test PR
- [ ] Verify `release-drafter.yml` creates draft releases on push to main
- [ ] Verify `pages.yml` builds and deploys docs correctly
- [ ] Verify `claude-pr-review.yml` reviews PRs when triggered

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Centralize CI workflows by replacing repository-specific implementations with calls to shared reusable workflows.

Build:
- Switch documentation build workflow to use shared pages workflow from doplaydo/pdk-ci-workflow.
- Replace local test workflow with shared test workflow, passing required secrets.
- Delegate release drafting workflow to shared reusable workflow.
- Delegate issue labeling workflow to shared reusable workflow.
- Delegate Claude PR review workflow to shared reusable workflow.