### PR TITLE
Add uv.lock exclude to pretty-format-toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: ruff-format
         exclude: ^cni/
   - repo: https://github.com/macisamuele/language-formatters-pre-commit-hooks
-    rev: v2.15.0
+    rev: v2.16.0
     hooks:
       - id: pretty-format-toml
         args: [--autofix]


### PR DESCRIPTION
## Summary
- Bump `language-formatters-pre-commit-hooks` to v2.16.0
- Add `exclude: ^uv\.lock$` to `pretty-format-toml` hook

## Test plan
- [ ] Verify pre-commit hooks still pass

## Summary by Sourcery

Build:
- Bump language-formatters-pre-commit-hooks in .pre-commit-config.yaml from v2.15.0 to v2.16.0.