### PR TITLE
bump gdsfactory to ~=9.40.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,18 +5,18 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools", "wheel", "ruff"]
 
 [project]
-authors = [{name = "gdsfactory", email = "contact@gdsfactory.com"}]
+authors = [{name = "gdsfactory~=9.40.2", email = "contact@gdsfactory.com"}]
 classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
-  "gdsfactory>=9.39.3",
+  "gdsfactory~=9.40.2",
   "gplugins[sax]~=2.0.0",
   "doroutes>=0.2.1",
   "scikit-rf>=1.0.0",
-  "gdsfactoryplus"
+  "gdsfactory~=9.40.2"
 ]
 description = "IHP pdk"
 keywords = ["python"]
@@ -149,7 +149,7 @@ regex = '''
 directory = ".changelog.d"
 filename = "CHANGELOG.md"
 issue_format = "[#{issue}](https://github.com/gdsfactory/ihp/issues/{issue})"
-package = "gdsfactory"
+package = "gdsfactory~=9.40.2"
 start_string = "<!-- towncrier release notes start -->\n"
 template = ".changelog.d/changelog_template.jinja"
 title_format = "## [{version}](https://github.com/gdsfactory/ihp/releases/tag/v{version}) - {project_date}"


### PR DESCRIPTION
## Summary

- Bump gdsfactory from `gdsfactory>=9.39.3` to `~=9.40.2`
- Fixes [gdsfactory/gdsfactory#4485](https://github.com/gdsfactory/gdsfactory/issues/4485): `Pdk.__init__` in 9.40.0 didn't copy `__pydantic_extra__` slot, causing `copy.copy(pdk)` to raise `AttributeError`
- This crashed GF+ server on startup (`get_base_pdk` calls `copy(pdk)`)
- 9.40.1 has the fix, 9.40.2 adds regression test coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)