### PR TITLE
Add .spiceinit for automatic OSDI model loading

### DIFF
--- a/.spiceinit
+++ b/.spiceinit
@@ -1,0 +1,6 @@
+* IHP SG13G2 PDK initialization
+* Load OSDI compact models
+osdi ihp/models/ngspice/osdi/psp103.osdi
+osdi ihp/models/ngspice/osdi/psp103_nqs.osdi
+osdi ihp/models/ngspice/osdi/r3_cmc.osdi
+osdi ihp/models/ngspice/osdi/mosvar.osdi


### PR DESCRIPTION
## Summary
- Adds `.spiceinit` at the project root that loads the PDK's OSDI compact models (PSP103, PSP103_NQS, R3_CMC, MOSVAR) automatically when ngspice starts
- Uses relative paths — no `$PDK_ROOT`/`$PDK` environment variables needed
- Eliminates the need for manual `osdi` commands in simulation notebooks

## Context
The generic Mosaic simulation notebook doesn't know about PDK-specific OSDI files. By placing `.spiceinit` in the project root, ngspice loads them automatically when CWD is the project directory.

## Test plan
- [x] ngspice no longer warns "can't find spinit" 
- [x] IHP schematics simulate successfully without manual OSDI loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enhancements:
- Introduce a .spiceinit file that configures ngspice to load the PDK’s OSDI compact models using relative paths, removing the need for manual osdi commands in simulation workflows.