### PR TITLE
ci: skip docs build and claude review for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
       interval: monthly
     ignore:
       - dependency-name: "doplaydo/*"
+      - dependency-name: "jupyter-book"
 
   - package-ecosystem: github-actions
     cooldown:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -13,10 +13,11 @@ jobs:
   claude-review:
     # Run on PR events, or on issue comments that mention @claude
     if: |
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'issue_comment' &&
-       github.event.issue.pull_request &&
-       contains(github.event.comment.body, '@claude'))
+      github.actor != 'dependabot[bot]' &&
+      (github.event_name == 'pull_request' ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, '@claude')))
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   build-docs:
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     name: Sphinx docs to gh-pages
     steps:


### PR DESCRIPTION
## Summary
- Skip Sphinx docs build on Dependabot PRs (saves CI minutes)
- Skip Claude PR review on Dependabot PRs
- Ignore `jupyter-book` in Dependabot updates (pinned to 1.0.3)

## Test plan
- [ ] Verify Dependabot PRs no longer trigger docs build or Claude review
- [ ] Verify regular PRs still trigger all jobs normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Adjust CI workflows and Dependabot configuration to skip expensive docs and AI review jobs on Dependabot PRs and ignore jupyter-book updates.

CI:
- Skip the Claude PR review workflow when the actor is dependabot[bot].

Deployment:
- Skip the Sphinx docs build workflow when the actor is dependabot[bot].

Chores:
- Ignore jupyter-book dependency updates in Dependabot configuration.