### PR TITLE
Fix build_cell.py to filter to PDK-owned cells

### DIFF
--- a/build_cell.py
+++ b/build_cell.py
@@ -1,5 +1,12 @@
-"""Build a cell and write it to build/gds/<cell_name>.gds."""
+"""Build a cell and write it to build/gds/<cell_name>.gds.
 
+When cell_name is "all_cells", builds every PDK-owned cell that can be
+instantiated with default arguments and packs them into a single GDS.
+Cells from installed packages (site-packages / .venv) and cells that
+require positional arguments are skipped automatically.
+"""
+
+import inspect
 import sys
 from pathlib import Path
 
@@ -8,5 +15,38 @@ from gdsfactoryplus.core.pdk import get_pdk, register_cells
 cell_name = sys.argv[1]
 Path("build/gds").mkdir(parents=True, exist_ok=True)
 register_cells()
-c = get_pdk().cells[cell_name]()
-c.write_gds(f"build/gds/{cell_name}.gds")
+pdk = get_pdk()
+
+if cell_name == "all_cells":
+    import gdsfactory as gf
+
+    c = gf.Component("all_cells")
+    for name, func in sorted(pdk.cells.items()):
+        # Skip cells from installed packages (not PDK-owned)
+        try:
+            src = inspect.getfile(func)
+        except TypeError:
+            continue
+        if ".venv" in src or "site-packages" in src:
+            continue
+
+        # Skip cells that require positional arguments
+        sig = inspect.signature(func)
+        required = [
+            p
+            for p in sig.parameters.values()
+            if p.default is inspect.Parameter.empty
+            and p.kind not in (p.VAR_POSITIONAL, p.VAR_KEYWORD)
+        ]
+        if required:
+            print(f"Skipping {name}: requires arguments {[p.name for p in required]}")
+            continue
+
+        try:
+            c.add_ref(func())
+        except Exception as e:
+            print(f"Error instantiating cell {name}: {e}")
+    c.write_gds(f"build/gds/{cell_name}.gds")
+else:
+    c = pdk.cells[cell_name]()
+    c.write_gds(f"build/gds/{cell_name}.gds")


### PR DESCRIPTION
## Summary
- Filters `all_cells` build to PDK-owned cells only (skips site-packages/venv sources)
- Skips cells requiring positional arguments
- Prevents DRC workflow from failing on generic gdsfactory built-ins that reference missing layers (e.g. `WG`)

## Test plan
- [ ] Trigger DRC workflow on this branch and verify it completes
- [ ] Verify only IHP PDK cells are included in the output GDS

Upstream template proposal: doplaydo/pdk-ci-workflow#96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Update build_cell script to restrict the aggregated all_cells GDS build to safe, PDK-owned cells and keep single-cell builds unchanged.

New Features:
- Add support for generating an all_cells GDS containing only PDK-owned cells that can be instantiated without required arguments.

Bug Fixes:
- Avoid including non-PDK cells and cells that error on instantiation in the all_cells GDS build to prevent downstream DRC workflow failures.