### PR TITLE
Add gmsh installation for docs build

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   review:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/claude-pr-review.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/drc.yml
+++ b/.github/workflows/drc.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   drc:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/drc.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/model_coverage.yml
+++ b/.github/workflows/model_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/model_regression.yml
+++ b/.github/workflows/model_regression.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   model-regression:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/model_regression.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -8,7 +8,9 @@ on:
 jobs:
   docs:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/pages.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+      SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}
   deploy-docs:
     needs: docs
     if: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   draft:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/release-drafter.yml@main
-    secrets: inherit
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/test_code.yml
+++ b/.github/workflows/test_code.yml
@@ -7,4 +7,5 @@ on:
 jobs:
   test:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_code.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/test_coverage.yml
+++ b/.github/workflows/test_coverage.yml
@@ -8,4 +8,5 @@ on:
 jobs:
   coverage:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/test_coverage.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/.github/workflows/update_badges.yml
+++ b/.github/workflows/update_badges.yml
@@ -9,4 +9,5 @@ on:
 jobs:
   badges:
     uses: doplaydo/pdk-ci-workflow/.github/workflows/update_badges.yml@main
-    secrets: inherit
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,11 @@ build:
 	pip install build
 	python -m build
 
-docs-clean:
+gmsh:
+	sudo apt-get update
+	sudo apt-get install -y python3-gmsh gmsh libglu1-mesa libxi-dev libxmu-dev libglu1-mesa-dev
+
+docs-clean: gmsh
 	rm -rf docs/_build
 
 docs: docs-clean

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ build:
 
 gmsh:
 	sudo apt-get update
-	sudo apt-get install -y python3-gmsh gmsh libglu1-mesa libxi-dev libxmu-dev libglu1-mesa-dev
+	sudo apt-get install -y python3-gmsh gmsh libglu1-mesa libxi-dev libxmu-dev libglu1-mesa-dev libosmesa6 libegl1
 
 docs-clean: gmsh
 	rm -rf docs/_build

--- a/uv.lock
+++ b/uv.lock
@@ -1329,7 +1329,7 @@ simulation = [
 requires-dist = [
     { name = "autodoc-pydantic", marker = "extra == 'docs'" },
     { name = "doroutes", specifier = ">=0.2.1" },
-    { name = "gdsfactory", specifier = ">=9.39.3" },
+    { name = "gdsfactory", specifier = "~=9.40.1" },
     { name = "gdsfactoryplus" },
     { name = "gplugins", extras = ["sax"], specifier = "~=2.0.0" },
     { name = "gsim", marker = "python_full_version >= '3.12' and extra == 'simulation'", specifier = ">=0.0.8" },


### PR DESCRIPTION
## Summary
- Adds a `gmsh` Makefile target that installs gmsh and its dependencies (libglu1-mesa, libxi-dev, libxmu-dev)
- Makes `docs-clean` depend on `gmsh` so the docs build environment has the required meshing tools

## Test plan
- [ ] Verify `make docs` succeeds in CI with gmsh available

## Summary by Sourcery

Add a Makefile target to install gmsh and its system dependencies and ensure the docs-clean step prepares a docs build environment with gmsh available.

Build:
- Add a gmsh Makefile target that installs gmsh and its required system libraries via apt-get.
- Make the docs-clean target depend on gmsh so documentation builds run with gmsh preinstalled.