### PR TITLE
refactor: consolidate cell tags onto @gf.cell decorator

### DIFF
--- a/ihp/cells/antennas.py
+++ b/ihp/cells/antennas.py
@@ -131,7 +131,6 @@ def dantenna_schematic(
     guardRingDistance: float = 1.0,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "diode", "antenna"]
     s.info["symbol"] = "diode"
     s.info["ports"] = [
         {"name": "1", "side": "top", "type": "electric"},
@@ -153,7 +152,7 @@ def dantenna_schematic(
     return s
 
 
-@gf.cell(schematic_function=dantenna_schematic, tags={"type": "antennas"})
+@gf.cell(schematic_function=dantenna_schematic, tags=["IHP", "diode", "antenna"])
 def dantenna(
     width: float = 0.78,
     length: float = 0.78,
@@ -269,7 +268,6 @@ def dpantenna_schematic(
     guardRingDistance: float = 1.0,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "diode", "antenna"]
     s.info["symbol"] = "diode"
     s.info["ports"] = [
         {"name": "1", "side": "top", "type": "electric"},
@@ -291,7 +289,7 @@ def dpantenna_schematic(
     return s
 
 
-@gf.cell(schematic_function=dpantenna_schematic, tags={"type": "antennas"})
+@gf.cell(schematic_function=dpantenna_schematic, tags=["IHP", "diode", "antenna"])
 def dpantenna(
     width: float = 0.78,
     length: float = 0.78,

--- a/ihp/cells/bjt_transistors.py
+++ b/ihp/cells/bjt_transistors.py
@@ -48,7 +48,6 @@ def npn13G2_schematic(
     CMetY2: float = 0,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bjt", "npn"]
     s.info["symbol"] = "npn"
     s.info["ports"] = [
         {"name": "BN", "side": "top", "type": "electric"},
@@ -79,7 +78,7 @@ def npn13G2_schematic(
     return s
 
 
-@gf.cell(schematic_function=npn13G2_schematic, tags={"type": "bjt_transistors"})
+@gf.cell(schematic_function=npn13G2_schematic, tags=["IHP", "bjt", "npn"])
 def npn13G2(
     baspolyx: float = 0.3,
     bipwinx: float = 0.07,
@@ -781,7 +780,6 @@ def npn13G2L_schematic(
     Nx: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bjt", "npn"]
     s.info["symbol"] = "npn"
     s.info["ports"] = [
         {"name": "BN", "side": "top", "type": "electric"},
@@ -810,7 +808,7 @@ def npn13G2L_schematic(
     return s
 
 
-@gf.cell(schematic_function=npn13G2L_schematic, tags={"type": "bjt_transistors"})
+@gf.cell(schematic_function=npn13G2L_schematic, tags=["IHP", "bjt", "npn"])
 def npn13G2L(
     emitter_length: float = 1,
     emitter_width: float = 0.07,
@@ -1374,7 +1372,6 @@ def npn13G2V_schematic(
     Nx: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bjt", "npn"]
     s.info["symbol"] = "npn"
     s.info["ports"] = [
         {"name": "BN", "side": "top", "type": "electric"},
@@ -1403,7 +1400,7 @@ def npn13G2V_schematic(
     return s
 
 
-@gf.cell(schematic_function=npn13G2V_schematic, tags={"type": "bjt_transistors"})
+@gf.cell(schematic_function=npn13G2V_schematic, tags=["IHP", "bjt", "npn"])
 def npn13G2V(
     emitter_length: float = 1,
     emitter_width: float = 0.12,
@@ -2073,7 +2070,6 @@ def contactArray(
 
 def pnpMPA_schematic(length: float = 2, width: float = 0.7) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bjt", "pnp"]
     s.info["symbol"] = "pnp"
     s.info["ports"] = [
         {"name": "E", "side": "bottom", "type": "electric"},
@@ -2097,7 +2093,7 @@ def pnpMPA_schematic(length: float = 2, width: float = 0.7) -> DSchematic:
     return s
 
 
-@gf.cell(schematic_function=pnpMPA_schematic, tags={"type": "bjt_transistors"})
+@gf.cell(schematic_function=pnpMPA_schematic, tags=["IHP", "bjt", "pnp"])
 def pnpMPA(length: float = 2, width: float = 0.7) -> gf.Component:
     """Returns the IHP pnpMPA BJT transistor as a gdsfactory Component.
 

--- a/ihp/cells/bondpads.py
+++ b/ihp/cells/bondpads.py
@@ -31,7 +31,6 @@ def bondpad_schematic(
 ) -> DSchematic:
     _shape_map = {"octagon": 0, "square": 1, "circle": 2}
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bondpad"]
     s.info["symbol"] = "pad"
     s.info["ports"] = [{"name": "PAD", "side": "top", "type": "electric"}]
     s.info["models"] = [
@@ -53,7 +52,7 @@ def bondpad_schematic(
     return s
 
 
-@gf.cell(schematic_function=bondpad_schematic, tags={"type": "bondpads"})
+@gf.cell(schematic_function=bondpad_schematic, tags=["IHP", "bondpad"])
 def bondpad(
     shape: Literal["octagon", "square", "circle"] = "octagon",
     diameter: float = 80.0,
@@ -136,7 +135,7 @@ def bondpad(
     return c
 
 
-@gf.cell(tags={"type": "bondpads"})
+@gf.cell(tags=["IHP", "bondpad", "array"])
 def bondpad_array(
     n_pads: int = 4,
     pad_pitch: float = 100.0,

--- a/ihp/cells/capacitors.py
+++ b/ihp/cells/capacitors.py
@@ -59,7 +59,7 @@ def cmom_extractor(
     return total_cap * (1 + fringe_field_factor)
 
 
-@gf.cell(tags={"type": "capacitors"})
+@gf.cell(tags=["IHP", "capacitor", "mom"])
 def cmom(
     nfingers: int = 1,
     length: float = 4.0,
@@ -319,7 +319,6 @@ def cmim_schematic(
     length: float = 6.0,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "capacitor", "mim"]
     s.info["symbol"] = "capacitor"
     s.info["ports"] = [
         {"name": "MINUS", "side": "left", "type": "electric"},
@@ -341,7 +340,7 @@ def cmim_schematic(
     return s
 
 
-@gf.cell(schematic_function=cmim_schematic, tags={"type": "capacitors"})
+@gf.cell(schematic_function=cmim_schematic, tags=["IHP", "capacitor", "mim"])
 def cmim(
     width: float = 6.0,
     length: float = 6.0,
@@ -563,7 +562,6 @@ def rfcmim_schematic(
     length: float = 7.0,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "capacitor", "mim", "rf"]
     s.info["symbol"] = "capacitor"
     s.info["ports"] = [
         {"name": "BN", "side": "bottom", "type": "electric"},
@@ -587,7 +585,7 @@ def rfcmim_schematic(
     return s
 
 
-@gf.cell(schematic_function=rfcmim_schematic, tags={"type": "capacitors"})
+@gf.cell(schematic_function=rfcmim_schematic, tags=["IHP", "capacitor", "mim", "rf"])
 def rfcmim(
     width: float = 7.0,
     length: float = 7.0,

--- a/ihp/cells/containers.py
+++ b/ihp/cells/containers.py
@@ -16,7 +16,7 @@ from ..cells_fixed import CuPillarPad_fixed
 __all__ = ["add_pads_top", "pack_doe", "pack_doe_grid"]
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["IHP", "container"])
 def add_pads_top(
     component: ComponentSpec = "straight",
     port_names: Strs | None = None,
@@ -89,7 +89,7 @@ def add_pads_top(
     )
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["IHP", "container"])
 def pack_doe(
     doe: ComponentSpec,
     settings: dict[str, tuple[Any, ...]],
@@ -132,7 +132,7 @@ def pack_doe(
     )
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["IHP", "container"])
 def pack_doe_grid(
     doe: ComponentSpec,
     settings: dict[str, tuple[Any, ...]],

--- a/ihp/cells/fet_transistors.py
+++ b/ihp/cells/fet_transistors.py
@@ -515,7 +515,6 @@ def nmos_schematic(
     m: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "lv"]
     s.info["symbol"] = "nmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -546,7 +545,7 @@ def nmos_schematic(
     return s
 
 
-@gf.cell(schematic_function=nmos_schematic, tags={"type": "fet_transistors"})
+@gf.cell(schematic_function=nmos_schematic, tags=["IHP", "mos", "lv"])
 def nmos(
     width: float = 0.15,
     length: float = 0.13,
@@ -591,7 +590,6 @@ def pmos_schematic(
     m: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "lv"]
     s.info["symbol"] = "pmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -617,7 +615,7 @@ def pmos_schematic(
     return s
 
 
-@gf.cell(schematic_function=pmos_schematic, tags={"type": "fet_transistors"})
+@gf.cell(schematic_function=pmos_schematic, tags=["IHP", "mos", "lv"])
 def pmos(
     width: float = 0.15,
     length: float = 0.13,
@@ -662,7 +660,6 @@ def nmos_hv_schematic(
     m: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "hv"]
     s.info["symbol"] = "nmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -688,7 +685,7 @@ def nmos_hv_schematic(
     return s
 
 
-@gf.cell(schematic_function=nmos_hv_schematic, tags={"type": "fet_transistors"})
+@gf.cell(schematic_function=nmos_hv_schematic, tags=["IHP", "mos", "hv"])
 def nmos_hv(
     width: float = 0.60,
     length: float = 0.45,
@@ -733,7 +730,6 @@ def pmos_hv_schematic(
     m: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "hv"]
     s.info["symbol"] = "pmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -759,7 +755,7 @@ def pmos_hv_schematic(
     return s
 
 
-@gf.cell(schematic_function=pmos_hv_schematic, tags={"type": "fet_transistors"})
+@gf.cell(schematic_function=pmos_hv_schematic, tags=["IHP", "mos", "hv"])
 def pmos_hv(
     width: float = 0.30,
     length: float = 0.40,

--- a/ihp/cells/inductors.py
+++ b/ihp/cells/inductors.py
@@ -11,7 +11,7 @@ def snap_to_grid(p, grid: float = 0.005):
     return round(p / grid) * grid
 
 
-@gf.cell(tags={"type": "inductors"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor2(
     width: float = 2.0,
     space: float = 2.1,
@@ -305,7 +305,7 @@ def inductor2(
     return c
 
 
-@gf.cell(tags={"type": "inductors"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor3(
     width: float = 2.0,
     space: float = 2.1,

--- a/ihp/cells/passives.py
+++ b/ihp/cells/passives.py
@@ -23,7 +23,6 @@ def svaricap_schematic(
     nf: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "varicap", "hv"]
     s.info["symbol"] = "varicap"
     s.info["ports"] = [
         {"name": "BN", "side": "top", "type": "electric"},
@@ -49,7 +48,7 @@ def svaricap_schematic(
     return s
 
 
-@gf.cell(schematic_function=svaricap_schematic, tags={"type": "passives"})
+@gf.cell(schematic_function=svaricap_schematic, tags=["IHP", "varicap", "hv"])
 def svaricap(
     width: float = 1.0,
     length: float = 1.0,
@@ -219,7 +218,6 @@ def esd_nmos_schematic(
     nf: int = 10,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "esd", "lv"]
     s.info["symbol"] = "nmos"
     s.info["ports"] = [
         {"name": "VDD", "side": "top", "type": "electric"},
@@ -241,7 +239,7 @@ def esd_nmos_schematic(
     return s
 
 
-@gf.cell(schematic_function=esd_nmos_schematic, tags={"type": "passives"})
+@gf.cell(schematic_function=esd_nmos_schematic, tags=["IHP", "esd", "lv"])
 def esd_nmos(
     width: float = 50.0,
     length: float = 0.5,
@@ -420,7 +418,6 @@ def ptap1_schematic(
     cols: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "tap", "p-type"]
     s.info["symbol"] = "tap"
     s.info["ports"] = [
         {"name": "P1", "side": "top", "type": "electric"},
@@ -442,7 +439,7 @@ def ptap1_schematic(
     return s
 
 
-@gf.cell(schematic_function=ptap1_schematic, tags={"type": "passives"})
+@gf.cell(schematic_function=ptap1_schematic, tags=["IHP", "tap", "p-type"])
 def ptap1(
     width: float = 1.0,
     length: float = 1.0,
@@ -562,7 +559,6 @@ def ntap1_schematic(
     cols: int = 1,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "tap", "n-type"]
     s.info["symbol"] = "tap"
     s.info["ports"] = [
         {"name": "P1", "side": "top", "type": "electric"},
@@ -584,7 +580,7 @@ def ntap1_schematic(
     return s
 
 
-@gf.cell(schematic_function=ntap1_schematic, tags={"type": "passives"})
+@gf.cell(schematic_function=ntap1_schematic, tags=["IHP", "tap", "n-type"])
 def ntap1(
     width: float = 1.0,
     length: float = 1.0,
@@ -708,7 +704,7 @@ def ntap1(
     return c
 
 
-@gf.cell(tags={"type": "passives"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring(
     width: float = 200.0,
     height: float = 200.0,
@@ -891,7 +887,7 @@ def sealring(
     return c
 
 
-@gf.cell(tags={"type": "passives"})
+@gf.cell(tags=["IHP", "guardring"])
 def guard_ring(
     width: float = 0.5,
     guardRingSpacing: float = 0.14,

--- a/ihp/cells/resistors.py
+++ b/ihp/cells/resistors.py
@@ -30,7 +30,6 @@ def rsil_schematic(
     resistance: float | None = None,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "resistor", "silicided"]
     s.info["symbol"] = "resistor"
     s.info["ports"] = [
         {"name": "P1", "side": "top", "type": "electric"},
@@ -54,7 +53,7 @@ def rsil_schematic(
     return s
 
 
-@gf.cell(schematic_function=rsil_schematic, tags={"type": "resistors"})
+@gf.cell(schematic_function=rsil_schematic, tags=["IHP", "resistor", "silicided"])
 def rsil(
     dy: float = 0.5,
     dx: float = 0.5,
@@ -239,7 +238,6 @@ def rppd_schematic(
     resistance: float | None = None,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "resistor", "unsilicided"]
     s.info["symbol"] = "resistor"
     s.info["ports"] = [
         {"name": "P1", "side": "top", "type": "electric"},
@@ -263,7 +261,7 @@ def rppd_schematic(
     return s
 
 
-@gf.cell(schematic_function=rppd_schematic, tags={"type": "resistors"})
+@gf.cell(schematic_function=rppd_schematic, tags=["IHP", "resistor", "unsilicided"])
 def rppd(
     dy: float = 0.5,
     dx: float = 0.5,
@@ -462,7 +460,6 @@ def rhigh_schematic(
     resistance: float | None = None,
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "resistor", "high-r"]
     s.info["symbol"] = "resistor"
     s.info["ports"] = [
         {"name": "P1", "side": "top", "type": "electric"},
@@ -486,7 +483,7 @@ def rhigh_schematic(
     return s
 
 
-@gf.cell(schematic_function=rhigh_schematic, tags={"type": "resistors"})
+@gf.cell(schematic_function=rhigh_schematic, tags=["IHP", "resistor", "high-r"])
 def rhigh(
     dy: float = 0.96,
     dx: float = 0.5,

--- a/ihp/cells/rf_transistors.py
+++ b/ihp/cells/rf_transistors.py
@@ -898,7 +898,6 @@ def rfnmos_schematic(
     guard_ring: str = "Yes",
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "lv", "rf"]
     s.info["symbol"] = "nmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -930,7 +929,7 @@ def rfnmos_schematic(
     return s
 
 
-@gf.cell(schematic_function=rfnmos_schematic, tags={"type": "rf_transistors"})
+@gf.cell(schematic_function=rfnmos_schematic, tags=["IHP", "mos", "lv", "rf"])
 def rfnmos(
     width: float = 1.0,
     length: float = 0.13,
@@ -997,7 +996,6 @@ def rfpmos_schematic(
     guard_ring: str = "Yes",
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "lv", "rf"]
     s.info["symbol"] = "pmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -1029,7 +1027,7 @@ def rfpmos_schematic(
     return s
 
 
-@gf.cell(schematic_function=rfpmos_schematic, tags={"type": "rf_transistors"})
+@gf.cell(schematic_function=rfpmos_schematic, tags=["IHP", "mos", "lv", "rf"])
 def rfpmos(
     width: float = 1.0,
     length: float = 0.13,
@@ -1096,7 +1094,6 @@ def rfnmos_hv_schematic(
     guard_ring: str = "Yes",
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "hv", "rf"]
     s.info["symbol"] = "nmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -1128,7 +1125,7 @@ def rfnmos_hv_schematic(
     return s
 
 
-@gf.cell(schematic_function=rfnmos_hv_schematic, tags={"type": "rf_transistors"})
+@gf.cell(schematic_function=rfnmos_hv_schematic, tags=["IHP", "mos", "hv", "rf"])
 def rfnmos_hv(
     width: float = 1.0,
     length: float = 0.45,
@@ -1195,7 +1192,6 @@ def rfpmos_hv_schematic(
     guard_ring: str = "Yes",
 ) -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "hv", "rf"]
     s.info["symbol"] = "pmos"
     s.info["ports"] = [
         {"name": "D", "side": "top", "type": "electric"},
@@ -1227,7 +1223,7 @@ def rfpmos_hv_schematic(
     return s
 
 
-@gf.cell(schematic_function=rfpmos_hv_schematic, tags={"type": "rf_transistors"})
+@gf.cell(schematic_function=rfpmos_hv_schematic, tags=["IHP", "mos", "hv", "rf"])
 def rfpmos_hv(
     width: float = 1.0,
     length: float = 0.40,

--- a/ihp/cells/text.py
+++ b/ihp/cells/text.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
 
 
-@gf.cell(tags={"type": "text"})
+@gf.cell(tags=["IHP", "text"])
 def text_rectangular(
     text: str = "abc",
     size: float = 3,
@@ -26,7 +26,7 @@ def text_rectangular(
     )
 
 
-@gf.cell(tags={"type": "text"})
+@gf.cell(tags=["IHP", "text"])
 def text_rectangular_multi_layer(
     text: str = "abc",
     layers: LayerSpecs = ("TopMetal2drawing",),

--- a/ihp/cells/via_stacks.py
+++ b/ihp/cells/via_stacks.py
@@ -76,7 +76,7 @@ def get_via_name(bottom_metal: str, top_metal: str) -> str | None:
     return None
 
 
-@gf.cell(tags={"type": "via_stacks"})
+@gf.cell(tags=["IHP", "via", "array"])
 def via_array(
     via_type: str = "Via1",
     columns: int = 2,
@@ -167,7 +167,7 @@ def via_array(
     return c
 
 
-@gf.cell(tags={"type": "via_stacks"})
+@gf.cell(tags=["IHP", "via", "stack"])
 def via_stack(
     bottom_layer: str = "Metal1",
     top_layer: str = "Metal2",
@@ -387,7 +387,7 @@ def via_stack(
     return c
 
 
-@gf.cell(tags={"type": "via_stacks"})
+@gf.cell(tags=["IHP", "via", "stack"])
 def via_stack_with_pads(
     bottom_layer: str = "Metal1",
     top_layer: str = "TopMetal2",

--- a/ihp/cells/waveguides.py
+++ b/ihp/cells/waveguides.py
@@ -5,7 +5,7 @@ from gdsfactory.cross_section import port_names_electrical, port_types_electrica
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "waveguide", "straight"])
 def straight(
     length: float = 10,
     cross_section: CrossSectionSpec = "strip",
@@ -25,7 +25,7 @@ def straight(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "waveguide", "bend"])
 def bend_euler(
     radius: float | None = None,
     angle: float = 90,
@@ -57,7 +57,7 @@ def bend_euler(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "waveguide", "bend"])
 def bend_s(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "strip",
@@ -84,7 +84,7 @@ def bend_s(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "corner"])
 def wire_corner(
     cross_section: CrossSectionSpec = "metal_routing", width: float | None = None
 ) -> gf.Component:
@@ -103,7 +103,7 @@ def wire_corner(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "corner"])
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
@@ -134,7 +134,7 @@ def wire_corner45(
 ####################
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "straight"])
 def straight_metal(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal_routing",
@@ -152,7 +152,7 @@ def straight_metal(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "bend"])
 def bend_metal(
     radius: float | None = None,
     angle: float = 90,
@@ -184,7 +184,7 @@ def bend_metal(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "bend"])
 def bend_s_metal(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal_routing",

--- a/ihp/cells2/antennas.py
+++ b/ihp/cells2/antennas.py
@@ -10,7 +10,7 @@ from .ihp_pycell import dpantenna as dpantennaIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "antennas"})
+@gf.cell(tags=["IHP", "diode", "antenna"])
 def dantenna(
     width: float = 0.78,
     length: float = 0.78,
@@ -80,7 +80,7 @@ def dantenna(
     return c
 
 
-@gf.cell(tags={"type": "antennas"})
+@gf.cell(tags=["IHP", "diode", "antenna"])
 def dpantenna(
     width: float = 0.78,
     length: float = 0.78,

--- a/ihp/cells2/bjt_transistors.py
+++ b/ihp/cells2/bjt_transistors.py
@@ -8,7 +8,7 @@ from .ihp_pycell import pnpMPA as pnpMPAIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "bjt_transistors"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2(
     STI: float = 0.44,
     baspolyx: float = 0.3,
@@ -104,7 +104,7 @@ def npn13G2(
     return c
 
 
-@gf.cell(tags={"type": "bjt_transistors"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2L(
     Nx: int = 1,
     emitter_length: float = 1,
@@ -168,7 +168,7 @@ def npn13G2L(
     return c
 
 
-@gf.cell(tags={"type": "bjt_transistors"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2V(
     Nx: int = 1,
     emitter_length: float = 1,
@@ -232,7 +232,7 @@ def npn13G2V(
     return c
 
 
-@gf.cell(tags={"type": "bjt_transistors"})
+@gf.cell(tags=["IHP", "bjt", "pnp"])
 def pnpMPA(
     width: float = 0.7,
     length: float = 2,

--- a/ihp/cells2/bondpads.py
+++ b/ihp/cells2/bondpads.py
@@ -9,7 +9,7 @@ from .ihp_pycell import bondpad as bondpadIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "bondpads"})
+@gf.cell(tags=["IHP", "bondpad"])
 def bondpad(
     shape: Literal["octagon", "square", "circle"] = "octagon",
     stack: Literal["t", "nil"] = "t",
@@ -72,7 +72,7 @@ def bondpad(
     return c
 
 
-@gf.cell(tags={"type": "bondpads"})
+@gf.cell(tags=["IHP", "bondpad", "array"])
 def bondpad_array(
     n_pads: int = 4,
     pad_pitch: float = 100.0,

--- a/ihp/cells2/capacitors.py
+++ b/ihp/cells2/capacitors.py
@@ -12,7 +12,7 @@ from .ihp_pycell import rfcmim as rfcmimIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "capacitors"})
+@gf.cell(tags=["IHP", "capacitor", "mim"])
 def cmim(
     width: float = 6.99,
     length: float = 6.99,
@@ -86,7 +86,7 @@ def cmim(
     return c
 
 
-@gf.cell(tags={"type": "capacitors"})
+@gf.cell(tags=["IHP", "capacitor", "mim", "rf"])
 def rfcmim(
     width: float = 6.99,
     length: float = 6.99,
@@ -159,7 +159,7 @@ def rfcmim(
     return c
 
 
-@gf.cell(tags={"type": "capacitors"})
+@gf.cell(tags=["IHP", "varicap", "hv"])
 def svaricap(
     width: Literal["3.74u", "9.74u"] = "9.74u",
     length: Literal["0.3u", "0.8u"] = "0.8u",

--- a/ihp/cells2/containers.py
+++ b/ihp/cells2/containers.py
@@ -12,7 +12,7 @@ from gdsfactory.typings import (
 )
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["IHP", "container"])
 def add_pads_top(
     component: ComponentSpec = "straight",
     port_names: Strs | None = None,
@@ -85,7 +85,7 @@ def add_pads_top(
     )
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["IHP", "container"])
 def pack_doe(
     doe: ComponentSpec,
     settings: dict[str, tuple[Any, ...]],
@@ -128,7 +128,7 @@ def pack_doe(
     )
 
 
-@gf.cell(tags={"type": "containers"})
+@gf.cell(tags=["IHP", "container"])
 def pack_doe_grid(
     doe: ComponentSpec,
     settings: dict[str, tuple[Any, ...]],

--- a/ihp/cells2/fixed.py
+++ b/ihp/cells2/fixed.py
@@ -17,7 +17,7 @@ gdsdir = PATH.gds
 import_gds = partial(gf.import_gds, post_process=_add_ports)
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bondpad"])
 def CuPillarPad() -> gf.Component:
     """Returns CuPillarPad fixed cell.
 
@@ -46,7 +46,7 @@ def CuPillarPad() -> gf.Component:
     return c
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "inductor"])
 def L2_IND_LVS() -> gf.Component:
     """Returns L2_IND_LVS fixed cell.
 
@@ -61,7 +61,7 @@ def L2_IND_LVS() -> gf.Component:
     return import_gds(gdsdir / "L2_IND_LVS.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M1_GatPoly_CDNS_675179387644() -> gf.Component:
     """Returns M1_GatPoly_CDNS_675179387644 fixed cell.
 
@@ -76,7 +76,7 @@ def M1_GatPoly_CDNS_675179387644() -> gf.Component:
     return import_gds(gdsdir / "M1_GatPoly_CDNS_675179387644.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M2_M1_CDNS_675179387643() -> gf.Component:
     """Returns M2_M1_CDNS_675179387643 fixed cell.
 
@@ -91,7 +91,7 @@ def M2_M1_CDNS_675179387643() -> gf.Component:
     return import_gds(gdsdir / "M2_M1_CDNS_675179387643.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M3_M2_CDNS_675179387642() -> gf.Component:
     """Returns M3_M2_CDNS_675179387642 fixed cell.
 
@@ -106,7 +106,7 @@ def M3_M2_CDNS_675179387642() -> gf.Component:
     return import_gds(gdsdir / "M3_M2_CDNS_675179387642.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M4_M3_CDNS_675179387641() -> gf.Component:
     """Returns M4_M3_CDNS_675179387641 fixed cell.
 
@@ -121,7 +121,7 @@ def M4_M3_CDNS_675179387641() -> gf.Component:
     return import_gds(gdsdir / "M4_M3_CDNS_675179387641.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M5_M4_CDNS_675179387640() -> gf.Component:
     """Returns M5_M4_CDNS_675179387640 fixed cell.
 
@@ -136,7 +136,7 @@ def M5_M4_CDNS_675179387640() -> gf.Component:
     return import_gds(gdsdir / "M5_M4_CDNS_675179387640.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "fill"])
 def NoFillerStack() -> gf.Component:
     """Returns NoFillerStack fixed cell.
 
@@ -151,7 +151,7 @@ def NoFillerStack() -> gf.Component:
     return import_gds(gdsdir / "NoFillerStack.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "varicap", "hv"])
 def SVaricap() -> gf.Component:
     """Returns SVaricap fixed cell.
 
@@ -166,7 +166,7 @@ def SVaricap() -> gf.Component:
     return import_gds(gdsdir / "SVaricap.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def TM1_M5_CDNS_675179387645() -> gf.Component:
     """Returns TM1_M5_CDNS_675179387645 fixed cell.
 
@@ -181,7 +181,7 @@ def TM1_M5_CDNS_675179387645() -> gf.Component:
     return import_gds(gdsdir / "TM1_M5_CDNS_675179387645.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def TM2_TM1_CDNS_675179387646() -> gf.Component:
     """Returns TM2_TM1_CDNS_675179387646 fixed cell.
 
@@ -196,7 +196,7 @@ def TM2_TM1_CDNS_675179387646() -> gf.Component:
     return import_gds(gdsdir / "TM2_TM1_CDNS_675179387646.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via", "tsv"])
 def TSV() -> gf.Component:
     """Returns TSV fixed cell.
 
@@ -211,7 +211,7 @@ def TSV() -> gf.Component:
     return import_gds(gdsdir / "TSV.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via", "stack"])
 def ViaStack() -> gf.Component:
     """Returns ViaStack fixed cell.
 
@@ -226,7 +226,7 @@ def ViaStack() -> gf.Component:
     return import_gds(gdsdir / "ViaStack.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bondpad"])
 def bondpad() -> gf.Component:
     """Returns bondpad fixed cell.
 
@@ -241,7 +241,7 @@ def bondpad() -> gf.Component:
     return import_gds(gdsdir / "bondpad.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "text"])
 def chipText() -> gf.Component:
     """Returns chipText fixed cell.
 
@@ -256,7 +256,7 @@ def chipText() -> gf.Component:
     return import_gds(gdsdir / "chipText.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "capacitor", "mim"])
 def cmim() -> gf.Component:
     """Returns cmim fixed cell.
 
@@ -271,7 +271,7 @@ def cmim() -> gf.Component:
     return import_gds(gdsdir / "cmim.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "layer"])
 def colors_and_stipples() -> gf.Component:
     """Returns colors_and_stipples fixed cell.
 
@@ -286,7 +286,7 @@ def colors_and_stipples() -> gf.Component:
     return import_gds(gdsdir / "colors_and_stipples.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "diode", "antenna"])
 def dantenna() -> gf.Component:
     """Returns dantenna fixed cell.
 
@@ -301,7 +301,7 @@ def dantenna() -> gf.Component:
     return import_gds(gdsdir / "dantenna.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "probe"])
 def diffstbprobe() -> gf.Component:
     """Returns diffstbprobe fixed cell.
 
@@ -316,7 +316,7 @@ def diffstbprobe() -> gf.Component:
     return import_gds(gdsdir / "diffstbprobe.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "esd"])
 def diodevdd_2kv() -> gf.Component:
     """Returns diodevdd_2kv fixed cell.
 
@@ -331,7 +331,7 @@ def diodevdd_2kv() -> gf.Component:
     return import_gds(gdsdir / "diodevdd_2kv.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "esd"])
 def diodevdd_4kv() -> gf.Component:
     """Returns diodevdd_4kv fixed cell.
 
@@ -346,7 +346,7 @@ def diodevdd_4kv() -> gf.Component:
     return import_gds(gdsdir / "diodevdd_4kv.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "esd"])
 def diodevss_2kv() -> gf.Component:
     """Returns diodevss_2kv fixed cell.
 
@@ -361,7 +361,7 @@ def diodevss_2kv() -> gf.Component:
     return import_gds(gdsdir / "diodevss_2kv.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "esd"])
 def diodevss_4kv() -> gf.Component:
     """Returns diodevss_4kv fixed cell.
 
@@ -376,7 +376,7 @@ def diodevss_4kv() -> gf.Component:
     return import_gds(gdsdir / "diodevss_4kv.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "diode", "antenna"])
 def dpantenna() -> gf.Component:
     """Returns dpantenna fixed cell.
 
@@ -391,7 +391,7 @@ def dpantenna() -> gf.Component:
     return import_gds(gdsdir / "dpantenna.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "resistor"])
 def dummy1() -> gf.Component:
     """Returns dummy1 fixed cell.
 
@@ -406,7 +406,7 @@ def dummy1() -> gf.Component:
     return import_gds(gdsdir / "dummy1.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor2() -> gf.Component:
     """Returns inductor2 fixed cell.
 
@@ -421,7 +421,7 @@ def inductor2() -> gf.Component:
     return import_gds(gdsdir / "inductor2.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor3() -> gf.Component:
     """Returns inductor3 fixed cell.
 
@@ -436,7 +436,7 @@ def inductor3() -> gf.Component:
     return import_gds(gdsdir / "inductor3.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "probe"])
 def iprobe() -> gf.Component:
     """Returns iprobe fixed cell.
 
@@ -451,7 +451,7 @@ def iprobe() -> gf.Component:
     return import_gds(gdsdir / "iprobe.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "diode", "antenna"])
 def isolbox() -> gf.Component:
     """Returns isolbox fixed cell.
 
@@ -466,7 +466,7 @@ def isolbox() -> gf.Component:
     return import_gds(gdsdir / "isolbox.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "resistor"])
 def lvsres() -> gf.Component:
     """Returns lvsres fixed cell.
 
@@ -481,7 +481,7 @@ def lvsres() -> gf.Component:
     return import_gds(gdsdir / "lvsres.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "lv"])
 def nmos() -> gf.Component:
     """Returns nmos fixed cell.
 
@@ -496,7 +496,7 @@ def nmos() -> gf.Component:
     return import_gds(gdsdir / "nmos.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "hv"])
 def nmosHV() -> gf.Component:
     """Returns nmosHV fixed cell.
 
@@ -511,7 +511,7 @@ def nmosHV() -> gf.Component:
     return import_gds(gdsdir / "nmosHV.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "lv"])
 def nmoscl_2() -> gf.Component:
     """Returns nmoscl_2 fixed cell.
 
@@ -526,7 +526,7 @@ def nmoscl_2() -> gf.Component:
     return import_gds(gdsdir / "nmoscl_2.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "lv"])
 def nmoscl_4() -> gf.Component:
     """Returns nmoscl_4 fixed cell.
 
@@ -541,7 +541,7 @@ def nmoscl_4() -> gf.Component:
     return import_gds(gdsdir / "nmoscl_4.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2() -> gf.Component:
     """Returns npn13G2 fixed cell.
 
@@ -556,7 +556,7 @@ def npn13G2() -> gf.Component:
     return import_gds(gdsdir / "npn13G2.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2L() -> gf.Component:
     """Returns npn13G2L fixed cell.
 
@@ -571,7 +571,7 @@ def npn13G2L() -> gf.Component:
     return import_gds(gdsdir / "npn13G2L.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2V() -> gf.Component:
     """Returns npn13G2V fixed cell.
 
@@ -586,7 +586,7 @@ def npn13G2V() -> gf.Component:
     return import_gds(gdsdir / "npn13G2V.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2_base_CDNS_675179387640() -> gf.Component:
     """Returns npn13G2_base_CDNS_675179387640 fixed cell.
 
@@ -601,7 +601,7 @@ def npn13G2_base_CDNS_675179387640() -> gf.Component:
     return import_gds(gdsdir / "npn13G2_base_CDNS_675179387640.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "tap", "n-type"])
 def ntap() -> gf.Component:
     """Returns ntap fixed cell.
 
@@ -616,7 +616,7 @@ def ntap() -> gf.Component:
     return import_gds(gdsdir / "ntap.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "tap", "n-type"])
 def ntap1() -> gf.Component:
     """Returns ntap1 fixed cell.
 
@@ -631,7 +631,7 @@ def ntap1() -> gf.Component:
     return import_gds(gdsdir / "ntap1.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "lv"])
 def pmos() -> gf.Component:
     """Returns pmos fixed cell.
 
@@ -646,7 +646,7 @@ def pmos() -> gf.Component:
     return import_gds(gdsdir / "pmos.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "hv"])
 def pmosHV() -> gf.Component:
     """Returns pmosHV fixed cell.
 
@@ -661,7 +661,7 @@ def pmosHV() -> gf.Component:
     return import_gds(gdsdir / "pmosHV.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bjt", "pnp"])
 def pnpMPA() -> gf.Component:
     """Returns pnpMPA fixed cell.
 
@@ -676,7 +676,7 @@ def pnpMPA() -> gf.Component:
     return import_gds(gdsdir / "pnpMPA.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "tap", "p-type"])
 def ptap() -> gf.Component:
     """Returns ptap fixed cell.
 
@@ -691,7 +691,7 @@ def ptap() -> gf.Component:
     return import_gds(gdsdir / "ptap.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "tap", "p-type"])
 def ptap1() -> gf.Component:
     """Returns ptap1 fixed cell.
 
@@ -706,7 +706,7 @@ def ptap1() -> gf.Component:
     return import_gds(gdsdir / "ptap1.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "capacitor", "mim", "rf"])
 def rfcmim() -> gf.Component:
     """Returns rfcmim fixed cell.
 
@@ -721,7 +721,7 @@ def rfcmim() -> gf.Component:
     return import_gds(gdsdir / "rfcmim.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "lv", "rf"])
 def rfnmos() -> gf.Component:
     """Returns rfnmos fixed cell.
 
@@ -736,7 +736,7 @@ def rfnmos() -> gf.Component:
     return import_gds(gdsdir / "rfnmos.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "hv", "rf"])
 def rfnmosHV() -> gf.Component:
     """Returns rfnmosHV fixed cell.
 
@@ -751,7 +751,7 @@ def rfnmosHV() -> gf.Component:
     return import_gds(gdsdir / "rfnmosHV.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "lv", "rf"])
 def rfpmos() -> gf.Component:
     """Returns rfpmos fixed cell.
 
@@ -766,7 +766,7 @@ def rfpmos() -> gf.Component:
     return import_gds(gdsdir / "rfpmos.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "mos", "hv", "rf"])
 def rfpmosHV() -> gf.Component:
     """Returns rfpmosHV fixed cell.
 
@@ -781,7 +781,7 @@ def rfpmosHV() -> gf.Component:
     return import_gds(gdsdir / "rfpmosHV.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "resistor", "high-r"])
 def rhigh() -> gf.Component:
     """Returns rhigh fixed cell.
 
@@ -796,7 +796,7 @@ def rhigh() -> gf.Component:
     return import_gds(gdsdir / "rhigh.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "resistor", "unsilicided"])
 def rppd() -> gf.Component:
     """Returns rppd fixed cell.
 
@@ -811,7 +811,7 @@ def rppd() -> gf.Component:
     return import_gds(gdsdir / "rppd.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "resistor", "silicided"])
 def rsil() -> gf.Component:
     """Returns rsil fixed cell.
 
@@ -826,7 +826,7 @@ def rsil() -> gf.Component:
     return import_gds(gdsdir / "rsil.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "diode", "schottky"])
 def schottky_nbl1() -> gf.Component:
     """Returns schottky_nbl1 fixed cell.
 
@@ -841,7 +841,7 @@ def schottky_nbl1() -> gf.Component:
     return import_gds(gdsdir / "schottky_nbl1.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "esd"])
 def scr1() -> gf.Component:
     """Returns scr1 fixed cell.
 
@@ -856,7 +856,7 @@ def scr1() -> gf.Component:
     return import_gds(gdsdir / "scr1.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring_CDNS_675179387642() -> gf.Component:
     """Returns sealring_CDNS_675179387642 fixed cell.
 
@@ -871,7 +871,7 @@ def sealring_CDNS_675179387642() -> gf.Component:
     return import_gds(gdsdir / "sealring_CDNS_675179387642.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring_complete() -> gf.Component:
     """Returns sealring_complete fixed cell.
 
@@ -886,7 +886,7 @@ def sealring_complete() -> gf.Component:
     return import_gds(gdsdir / "sealring_complete.gds")
 
 
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring_corner_CDNS_675179387641() -> gf.Component:
     """Returns sealring_corner_CDNS_675179387641 fixed cell.
 

--- a/ihp/cells2/inductors.py
+++ b/ihp/cells2/inductors.py
@@ -8,7 +8,7 @@ from .ihp_pycell import inductor3 as inductor3IHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "inductors"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor2(
     width: float = 2,
     space: float = 2.1,
@@ -88,7 +88,7 @@ def inductor2(
     return c
 
 
-@gf.cell(tags={"type": "inductors"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor3(
     width: float = 2,
     space: float = 2.1,

--- a/ihp/cells2/mos_transistors.py
+++ b/ihp/cells2/mos_transistors.py
@@ -15,7 +15,7 @@ from .ihp_pycell import rfpmosHV as rfpmosHVIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "lv"])
 def nmos(
     w: float = 0.15,
     l: float = 0.13,
@@ -88,7 +88,7 @@ def nmos(
     return c
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "hv"])
 def nmosHV(
     w: float = 0.60,
     l: float = 0.45,
@@ -163,7 +163,7 @@ def nmosHV(
     return c
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "lv"])
 def pmos(
     w: float = 0.15,
     l: float = 0.13,
@@ -236,7 +236,7 @@ def pmos(
     return c
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "hv"])
 def pmosHV(
     w: float = 0.30,
     l: float = 0.40,
@@ -310,7 +310,7 @@ def pmosHV(
     return c
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "lv", "rf"])
 def rfnmos(
     w: float = 1.0,
     l: float = 0.72,
@@ -395,7 +395,7 @@ def rfnmos(
     return c
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "hv", "rf"])
 def rfnmosHV(
     w: float = 1.0,
     l: float = 0.72,
@@ -459,7 +459,7 @@ def rfnmosHV(
     return c
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "lv", "rf"])
 def rfpmos(
     w: float = 1.0,
     l: float = 0.72,
@@ -523,7 +523,7 @@ def rfpmos(
     return c
 
 
-@gf.cell(tags={"type": "mos_transistors"})
+@gf.cell(tags=["IHP", "mos", "hv", "rf"])
 def rfpmosHV(
     w: float = 1.0,
     l: float = 0.72,

--- a/ihp/cells2/passives.py
+++ b/ihp/cells2/passives.py
@@ -13,7 +13,7 @@ from .ihp_pycell import sealring as sealringIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "passives"})
+@gf.cell(tags=["IHP", "esd", "lv"])
 def esd(
     model: Literal[
         "diodevdd_2kv",
@@ -135,7 +135,7 @@ def esd(
     return c
 
 
-@gf.cell(tags={"type": "passives"})
+@gf.cell(tags=["IHP", "tap", "p-type"])
 def ptap1(
     width: float = 0.78,
     length: float = 0.78,
@@ -188,7 +188,7 @@ def ptap1(
     return c
 
 
-@gf.cell(tags={"type": "passives"})
+@gf.cell(tags=["IHP", "tap", "n-type"])
 def ntap1(
     width=0.78,
     length=0.78,
@@ -238,7 +238,7 @@ def ntap1(
     return c
 
 
-@gf.cell(tags={"type": "passives"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring(
     width: float = 400.0,
     height: float = 400.0,

--- a/ihp/cells2/resistors.py
+++ b/ihp/cells2/resistors.py
@@ -12,7 +12,7 @@ from .ihp_pycell import rsil as rsilIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "resistors"})
+@gf.cell(tags=["IHP", "resistor", "high-r"])
 def rhigh(
     length: float = 0.96,
     width: float = 0.5,
@@ -101,7 +101,7 @@ def rhigh(
     return c
 
 
-@gf.cell(tags={"type": "resistors"})
+@gf.cell(tags=["IHP", "resistor", "unsilicided"])
 def rppd(
     length: float = 0.5,
     width: float = 0.5,
@@ -190,7 +190,7 @@ def rppd(
     return c
 
 
-@gf.cell(tags={"type": "resistors"})
+@gf.cell(tags=["IHP", "resistor", "silicided"])
 def rsil(
     length: float = 0.5,
     width: float = 0.5,

--- a/ihp/cells2/text.py
+++ b/ihp/cells2/text.py
@@ -6,7 +6,7 @@ import gdsfactory as gf
 from gdsfactory.typings import ComponentSpec, LayerSpec, LayerSpecs
 
 
-@gf.cell(tags={"type": "text"})
+@gf.cell(tags=["IHP", "text"])
 def text_rectangular(
     text: str = "abc",
     size: float = 3,
@@ -26,7 +26,7 @@ def text_rectangular(
     )
 
 
-@gf.cell(tags={"type": "text"})
+@gf.cell(tags=["IHP", "text"])
 def text_rectangular_multi_layer(
     text: str = "abc",
     layers: LayerSpecs = ("TOPMETAL2",),

--- a/ihp/cells2/via_stacks.py
+++ b/ihp/cells2/via_stacks.py
@@ -10,7 +10,7 @@ from .ihp_pycell import via_stack as via_stackIHP
 from .utils import *
 
 
-@gf.cell(tags={"type": "via_stacks"})
+@gf.cell(tags=["IHP", "via", "stack"])
 def via_stack(
     bottom_layer: Literal[
         "Activ",
@@ -111,7 +111,7 @@ def via_stack(
     return c
 
 
-@gf.cell(tags={"type": "via_stacks"})
+@gf.cell(tags=["IHP", "fill"])
 def no_filler_stack(
     width: int = 10,
     length: int = 10,

--- a/ihp/cells2/waveguides.py
+++ b/ihp/cells2/waveguides.py
@@ -5,7 +5,7 @@ from gdsfactory.cross_section import port_names_electrical, port_types_electrica
 from gdsfactory.typings import CrossSectionSpec, LayerSpec, Size
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "waveguide", "straight"])
 def straight(
     length: float = 10,
     cross_section: CrossSectionSpec = "strip",
@@ -25,7 +25,7 @@ def straight(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "waveguide", "bend"])
 def bend_euler(
     radius: float | None = None,
     angle: float = 90,
@@ -57,7 +57,7 @@ def bend_euler(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "waveguide", "bend"])
 def bend_s(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "strip",
@@ -84,7 +84,7 @@ def bend_s(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "corner"])
 def wire_corner(
     cross_section: CrossSectionSpec = "metal_routing", width: float | None = None
 ) -> gf.Component:
@@ -103,7 +103,7 @@ def wire_corner(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "corner"])
 def wire_corner45(
     cross_section: CrossSectionSpec = "metal_routing",
     radius: float = 10,
@@ -134,7 +134,7 @@ def wire_corner45(
 ####################
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "straight"])
 def straight_metal(
     length: float = 10,
     cross_section: CrossSectionSpec = "metal_routing",
@@ -152,7 +152,7 @@ def straight_metal(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "bend"])
 def bend_metal(
     radius: float | None = None,
     angle: float = 90,
@@ -177,7 +177,7 @@ def bend_metal(
     )
 
 
-@gf.cell(tags={"type": "waveguides"})
+@gf.cell(tags=["IHP", "wire", "bend"])
 def bend_s_metal(
     size: Size = (11, 1.8),
     cross_section: CrossSectionSpec = "metal_routing",

--- a/ihp/cells_fixed/__init__.py
+++ b/ihp/cells_fixed/__init__.py
@@ -49,7 +49,6 @@ import_gds = partial(gf.import_gds, post_process=_add_ports)
 
 def _svaricap_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "varicap", "hv"]
     s.info["symbol"] = "varicap"
     s.info["ports"] = [
         {"name": "bn", "side": "top", "type": "electric"},
@@ -77,7 +76,6 @@ def _svaricap_fixed_schematic() -> DSchematic:
 
 def _bondpad_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bondpad"]
     s.info["symbol"] = "pad"
     s.info["ports"] = [{"name": "PAD", "side": "top", "type": "electric"}]
     s.info["models"] = [
@@ -97,7 +95,6 @@ def _bondpad_fixed_schematic() -> DSchematic:
 
 def _cmim_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "capacitor", "mim"]
     s.info["symbol"] = "capacitor"
     s.info["ports"] = [
         {"name": "MINUS", "side": "left", "type": "electric"},
@@ -121,7 +118,6 @@ def _cmim_fixed_schematic() -> DSchematic:
 
 def _dantenna_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "diode", "antenna"]
     s.info["symbol"] = "diode"
     s.info["ports"] = [
         {"name": "1", "side": "top", "type": "electric"},
@@ -146,7 +142,6 @@ def _dantenna_fixed_schematic() -> DSchematic:
 def _esd_diode_fixed_schematic(model_name: str) -> DSchematic:
     """Shared schematic for ESD diode fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "esd"]
     s.info["symbol"] = "diode"
     s.info["ports"] = [
         {"name": "VDD", "side": "top", "type": "electric"},
@@ -188,7 +183,6 @@ def _diodevss_4kv_fixed_schematic() -> DSchematic:
 
 def _dpantenna_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "diode", "antenna"]
     s.info["symbol"] = "diode"
     s.info["ports"] = [
         {"name": "1", "side": "top", "type": "electric"},
@@ -212,7 +206,6 @@ def _dpantenna_fixed_schematic() -> DSchematic:
 
 def _dummy1_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "resistor"]
     s.info["symbol"] = "resistor"
     s.info["ports"] = [
         {"name": "W", "side": "left", "type": "electric"},
@@ -236,7 +229,6 @@ def _dummy1_fixed_schematic() -> DSchematic:
 
 def _isolbox_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "diode", "antenna"]
     s.info["symbol"] = "ckt"
     s.info["ports"] = [
         {"name": "bn", "side": "bottom", "type": "electric"},
@@ -263,7 +255,6 @@ def _isolbox_fixed_schematic() -> DSchematic:
 def _lv_mos_fixed_schematic(model_name: str, symbol: str) -> DSchematic:
     """Shared schematic for LV MOS fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "lv"]
     s.info["symbol"] = symbol
     s.info["ports"] = [
         {"name": "d", "side": "top", "type": "electric"},
@@ -292,7 +283,6 @@ def _lv_mos_fixed_schematic(model_name: str, symbol: str) -> DSchematic:
 def _hv_mos_fixed_schematic(model_name: str, symbol: str) -> DSchematic:
     """Shared schematic for HV MOS fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "hv"]
     s.info["symbol"] = symbol
     s.info["ports"] = [
         {"name": "d", "side": "top", "type": "electric"},
@@ -321,7 +311,6 @@ def _hv_mos_fixed_schematic(model_name: str, symbol: str) -> DSchematic:
 def _rf_lv_mos_fixed_schematic(model_name: str, symbol: str) -> DSchematic:
     """Shared schematic for RF LV MOS fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "lv", "rf"]
     s.info["symbol"] = symbol
     s.info["ports"] = [
         {"name": "d", "side": "top", "type": "electric"},
@@ -350,7 +339,6 @@ def _rf_lv_mos_fixed_schematic(model_name: str, symbol: str) -> DSchematic:
 def _rf_hv_mos_fixed_schematic(model_name: str, symbol: str) -> DSchematic:
     """Shared schematic for RF HV MOS fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "hv", "rf"]
     s.info["symbol"] = symbol
     s.info["ports"] = [
         {"name": "d", "side": "top", "type": "electric"},
@@ -387,7 +375,6 @@ def _nmosHV_fixed_schematic() -> DSchematic:
 def _nmoscl_lv_fixed_schematic(model_name: str) -> DSchematic:
     """Shared schematic for nmoscl fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "mos", "lv"]
     s.info["symbol"] = "nmos"
     s.info["ports"] = [
         {"name": "VDD", "side": "top", "type": "electric"},
@@ -420,7 +407,6 @@ def _nmoscl_4_fixed_schematic() -> DSchematic:
 def _npn_fixed_schematic(model_name: str) -> DSchematic:
     """Shared schematic for NPN BJT fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bjt", "npn"]
     s.info["symbol"] = "npn"
     s.info["ports"] = [
         {"name": "bn", "side": "top", "type": "electric"},
@@ -461,7 +447,6 @@ def _npn13G2V_fixed_schematic() -> DSchematic:
 def _tap_fixed_schematic(model_name: str) -> DSchematic:
     """Shared schematic for tap fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "tap"]
     s.info["symbol"] = "tap"
     s.info["ports"] = [
         {"name": "1", "side": "top", "type": "electric"},
@@ -501,7 +486,6 @@ def _pmosHV_fixed_schematic() -> DSchematic:
 
 def _pnpMPA_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "bjt", "pnp"]
     s.info["symbol"] = "pnp"
     s.info["ports"] = [
         {"name": "e", "side": "bottom", "type": "electric"},
@@ -527,7 +511,6 @@ def _pnpMPA_fixed_schematic() -> DSchematic:
 
 def _rfcmim_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "capacitor", "mim", "rf"]
     s.info["symbol"] = "capacitor"
     s.info["ports"] = [
         {"name": "bn", "side": "bottom", "type": "electric"},
@@ -570,7 +553,6 @@ def _rfpmosHV_fixed_schematic() -> DSchematic:
 def _resistor_3port_fixed_schematic(model_name: str) -> DSchematic:
     """Shared schematic for 3-port resistor fixed cells."""
     s = DSchematic()
-    s.info["tags"] = ["IHP", "resistor"]
     s.info["symbol"] = "resistor"
     s.info["ports"] = [
         {"name": "1", "side": "top", "type": "electric"},
@@ -608,7 +590,6 @@ def _rsil_fixed_schematic() -> DSchematic:
 
 def _schottky_nbl1_fixed_schematic() -> DSchematic:
     s = DSchematic()
-    s.info["tags"] = ["IHP", "diode", "schottky"]
     s.info["symbol"] = "diode"
     s.info["ports"] = [
         {"name": "A", "side": "top", "type": "electric"},
@@ -638,7 +619,7 @@ def _schottky_nbl1_fixed_schematic() -> DSchematic:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bondpad"])
 def CuPillarPad_fixed() -> gf.Component:
     """Returns CuPillarPad fixed cell.
 
@@ -668,7 +649,7 @@ def CuPillarPad_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "inductor"])
 def L2_IND_LVS_fixed() -> gf.Component:
     """Returns L2_IND_LVS fixed cell.
 
@@ -684,7 +665,7 @@ def L2_IND_LVS_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M1_GatPoly_CDNS_675179387644_fixed() -> gf.Component:
     """Returns M1_GatPoly_CDNS_675179387644 fixed cell.
 
@@ -700,7 +681,7 @@ def M1_GatPoly_CDNS_675179387644_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M2_M1_CDNS_675179387643_fixed() -> gf.Component:
     """Returns M2_M1_CDNS_675179387643 fixed cell.
 
@@ -716,7 +697,7 @@ def M2_M1_CDNS_675179387643_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M3_M2_CDNS_675179387642_fixed() -> gf.Component:
     """Returns M3_M2_CDNS_675179387642 fixed cell.
 
@@ -732,7 +713,7 @@ def M3_M2_CDNS_675179387642_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M4_M3_CDNS_675179387641_fixed() -> gf.Component:
     """Returns M4_M3_CDNS_675179387641 fixed cell.
 
@@ -748,7 +729,7 @@ def M4_M3_CDNS_675179387641_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def M5_M4_CDNS_675179387640_fixed() -> gf.Component:
     """Returns M5_M4_CDNS_675179387640 fixed cell.
 
@@ -764,7 +745,7 @@ def M5_M4_CDNS_675179387640_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "fill"])
 def NoFillerStack_fixed() -> gf.Component:
     """Returns NoFillerStack fixed cell.
 
@@ -780,7 +761,7 @@ def NoFillerStack_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_svaricap_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_svaricap_fixed_schematic, tags=["IHP", "varicap", "hv"])
 def SVaricap_fixed() -> gf.Component:
     """Returns SVaricap fixed cell.
 
@@ -796,7 +777,7 @@ def SVaricap_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def TM1_M5_CDNS_675179387645_fixed() -> gf.Component:
     """Returns TM1_M5_CDNS_675179387645 fixed cell.
 
@@ -812,7 +793,7 @@ def TM1_M5_CDNS_675179387645_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via"])
 def TM2_TM1_CDNS_675179387646_fixed() -> gf.Component:
     """Returns TM2_TM1_CDNS_675179387646 fixed cell.
 
@@ -828,7 +809,7 @@ def TM2_TM1_CDNS_675179387646_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via", "tsv"])
 def TSV_fixed() -> gf.Component:
     """Returns TSV fixed cell.
 
@@ -844,7 +825,7 @@ def TSV_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "via", "stack"])
 def ViaStack_fixed() -> gf.Component:
     """Returns ViaStack fixed cell.
 
@@ -860,7 +841,7 @@ def ViaStack_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_bondpad_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_bondpad_fixed_schematic, tags=["IHP", "bondpad"])
 def bondpad_fixed() -> gf.Component:
     """Returns bondpad fixed cell.
 
@@ -876,7 +857,7 @@ def bondpad_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "text"])
 def chipText_fixed() -> gf.Component:
     """Returns chipText fixed cell.
 
@@ -892,7 +873,7 @@ def chipText_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_cmim_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_cmim_fixed_schematic, tags=["IHP", "capacitor", "mim"])
 def cmim_fixed() -> gf.Component:
     """Returns cmim fixed cell.
 
@@ -908,7 +889,7 @@ def cmim_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "layer"])
 def colors_and_stipples_fixed() -> gf.Component:
     """Returns colors_and_stipples fixed cell.
 
@@ -924,7 +905,7 @@ def colors_and_stipples_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_dantenna_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_dantenna_fixed_schematic, tags=["IHP", "diode", "antenna"])
 def dantenna_fixed() -> gf.Component:
     """Returns dantenna fixed cell.
 
@@ -940,7 +921,7 @@ def dantenna_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "probe"])
 def diffstbprobe_fixed() -> gf.Component:
     """Returns diffstbprobe fixed cell.
 
@@ -956,7 +937,7 @@ def diffstbprobe_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_diodevdd_2kv_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_diodevdd_2kv_fixed_schematic, tags=["IHP", "esd"])
 def diodevdd_2kv_fixed() -> gf.Component:
     """Returns diodevdd_2kv fixed cell.
 
@@ -972,7 +953,7 @@ def diodevdd_2kv_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_diodevdd_4kv_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_diodevdd_4kv_fixed_schematic, tags=["IHP", "esd"])
 def diodevdd_4kv_fixed() -> gf.Component:
     """Returns diodevdd_4kv fixed cell.
 
@@ -988,7 +969,7 @@ def diodevdd_4kv_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_diodevss_2kv_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_diodevss_2kv_fixed_schematic, tags=["IHP", "esd"])
 def diodevss_2kv_fixed() -> gf.Component:
     """Returns diodevss_2kv fixed cell.
 
@@ -1004,7 +985,7 @@ def diodevss_2kv_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_diodevss_4kv_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_diodevss_4kv_fixed_schematic, tags=["IHP", "esd"])
 def diodevss_4kv_fixed() -> gf.Component:
     """Returns diodevss_4kv fixed cell.
 
@@ -1020,7 +1001,7 @@ def diodevss_4kv_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_dpantenna_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_dpantenna_fixed_schematic, tags=["IHP", "diode", "antenna"])
 def dpantenna_fixed() -> gf.Component:
     """Returns dpantenna fixed cell.
 
@@ -1036,7 +1017,7 @@ def dpantenna_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_dummy1_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_dummy1_fixed_schematic, tags=["IHP", "resistor"])
 def dummy1_fixed() -> gf.Component:
     """Returns dummy1 fixed cell.
 
@@ -1052,7 +1033,7 @@ def dummy1_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor2_fixed() -> gf.Component:
     """Returns inductor2 fixed cell.
 
@@ -1068,7 +1049,7 @@ def inductor2_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "inductor"])
 def inductor3_fixed() -> gf.Component:
     """Returns inductor3 fixed cell.
 
@@ -1084,7 +1065,7 @@ def inductor3_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "probe"])
 def iprobe_fixed() -> gf.Component:
     """Returns iprobe fixed cell.
 
@@ -1100,7 +1081,7 @@ def iprobe_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_isolbox_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_isolbox_fixed_schematic, tags=["IHP", "diode", "antenna"])
 def isolbox_fixed() -> gf.Component:
     """Returns isolbox fixed cell.
 
@@ -1116,7 +1097,7 @@ def isolbox_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "resistor"])
 def lvsres_fixed() -> gf.Component:
     """Returns lvsres fixed cell.
 
@@ -1132,7 +1113,7 @@ def lvsres_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_nmos_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_nmos_fixed_schematic, tags=["IHP", "mos", "lv"])
 def nmos_fixed() -> gf.Component:
     """Returns nmos fixed cell.
 
@@ -1148,7 +1129,7 @@ def nmos_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_nmosHV_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_nmosHV_fixed_schematic, tags=["IHP", "mos", "hv"])
 def nmosHV_fixed() -> gf.Component:
     """Returns nmosHV fixed cell.
 
@@ -1164,7 +1145,7 @@ def nmosHV_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_nmoscl_2_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_nmoscl_2_fixed_schematic, tags=["IHP", "mos", "lv"])
 def nmoscl_2_fixed() -> gf.Component:
     """Returns nmoscl_2 fixed cell.
 
@@ -1180,7 +1161,7 @@ def nmoscl_2_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_nmoscl_4_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_nmoscl_4_fixed_schematic, tags=["IHP", "mos", "lv"])
 def nmoscl_4_fixed() -> gf.Component:
     """Returns nmoscl_4 fixed cell.
 
@@ -1196,7 +1177,7 @@ def nmoscl_4_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_npn13G2_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_npn13G2_fixed_schematic, tags=["IHP", "bjt", "npn"])
 def npn13G2_fixed() -> gf.Component:
     """Returns npn13G2 fixed cell.
 
@@ -1212,7 +1193,7 @@ def npn13G2_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_npn13G2L_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_npn13G2L_fixed_schematic, tags=["IHP", "bjt", "npn"])
 def npn13G2L_fixed() -> gf.Component:
     """Returns npn13G2L fixed cell.
 
@@ -1228,7 +1209,7 @@ def npn13G2L_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_npn13G2V_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_npn13G2V_fixed_schematic, tags=["IHP", "bjt", "npn"])
 def npn13G2V_fixed() -> gf.Component:
     """Returns npn13G2V fixed cell.
 
@@ -1244,7 +1225,7 @@ def npn13G2V_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "bjt", "npn"])
 def npn13G2_base_CDNS_675179387640_fixed() -> gf.Component:
     """Returns npn13G2_base_CDNS_675179387640 fixed cell.
 
@@ -1260,7 +1241,7 @@ def npn13G2_base_CDNS_675179387640_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "tap", "n-type"])
 def ntap_fixed() -> gf.Component:
     """Returns ntap fixed cell.
 
@@ -1277,7 +1258,7 @@ def ntap_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_ntap1_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_ntap1_fixed_schematic, tags=["IHP", "tap"])
 def ntap1_fixed() -> gf.Component:
     """Returns ntap1 fixed cell.
 
@@ -1293,7 +1274,7 @@ def ntap1_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_pmos_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_pmos_fixed_schematic, tags=["IHP", "mos", "lv"])
 def pmos_fixed() -> gf.Component:
     """Returns pmos fixed cell.
 
@@ -1309,7 +1290,7 @@ def pmos_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_pmosHV_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_pmosHV_fixed_schematic, tags=["IHP", "mos", "hv"])
 def pmosHV_fixed() -> gf.Component:
     """Returns pmosHV fixed cell.
 
@@ -1325,7 +1306,7 @@ def pmosHV_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_pnpMPA_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_pnpMPA_fixed_schematic, tags=["IHP", "bjt", "pnp"])
 def pnpMPA_fixed() -> gf.Component:
     """Returns pnpMPA fixed cell.
 
@@ -1341,7 +1322,7 @@ def pnpMPA_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "tap", "p-type"])
 def ptap_fixed() -> gf.Component:
     """Returns ptap fixed cell.
 
@@ -1358,7 +1339,7 @@ def ptap_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_ptap1_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_ptap1_fixed_schematic, tags=["IHP", "tap"])
 def ptap1_fixed() -> gf.Component:
     """Returns ptap1 fixed cell.
 
@@ -1374,7 +1355,7 @@ def ptap1_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rfcmim_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rfcmim_fixed_schematic, tags=["IHP", "capacitor", "mim", "rf"])
 def rfcmim_fixed() -> gf.Component:
     """Returns rfcmim fixed cell.
 
@@ -1390,7 +1371,7 @@ def rfcmim_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rfnmos_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rfnmos_fixed_schematic, tags=["IHP", "mos", "lv", "rf"])
 def rfnmos_fixed() -> gf.Component:
     """Returns rfnmos fixed cell.
 
@@ -1406,7 +1387,7 @@ def rfnmos_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rfnmosHV_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rfnmosHV_fixed_schematic, tags=["IHP", "mos", "hv", "rf"])
 def rfnmosHV_fixed() -> gf.Component:
     """Returns rfnmosHV fixed cell.
 
@@ -1422,7 +1403,7 @@ def rfnmosHV_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rfpmos_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rfpmos_fixed_schematic, tags=["IHP", "mos", "lv", "rf"])
 def rfpmos_fixed() -> gf.Component:
     """Returns rfpmos fixed cell.
 
@@ -1438,7 +1419,7 @@ def rfpmos_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rfpmosHV_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rfpmosHV_fixed_schematic, tags=["IHP", "mos", "hv", "rf"])
 def rfpmosHV_fixed() -> gf.Component:
     """Returns rfpmosHV fixed cell.
 
@@ -1454,7 +1435,7 @@ def rfpmosHV_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rhigh_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rhigh_fixed_schematic, tags=["IHP", "resistor"])
 def rhigh_fixed() -> gf.Component:
     """Returns rhigh fixed cell.
 
@@ -1470,7 +1451,7 @@ def rhigh_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rppd_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rppd_fixed_schematic, tags=["IHP", "resistor"])
 def rppd_fixed() -> gf.Component:
     """Returns rppd fixed cell.
 
@@ -1486,7 +1467,7 @@ def rppd_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rsil_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_rsil_fixed_schematic, tags=["IHP", "resistor"])
 def rsil_fixed() -> gf.Component:
     """Returns rsil fixed cell.
 
@@ -1502,7 +1483,7 @@ def rsil_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_schottky_nbl1_fixed_schematic, tags={"type": "fixed"})
+@gf.cell(schematic_function=_schottky_nbl1_fixed_schematic, tags=["IHP", "diode", "schottky"])
 def schottky_nbl1_fixed() -> gf.Component:
     """Returns schottky_nbl1 fixed cell.
 
@@ -1518,7 +1499,7 @@ def schottky_nbl1_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "esd"])
 def scr1_fixed() -> gf.Component:
     """Returns scr1 fixed cell.
 
@@ -1534,7 +1515,7 @@ def scr1_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring_CDNS_675179387642_fixed() -> gf.Component:
     """Returns sealring_CDNS_675179387642 fixed cell.
 
@@ -1550,7 +1531,7 @@ def sealring_CDNS_675179387642_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring_complete_fixed() -> gf.Component:
     """Returns sealring_complete fixed cell.
 
@@ -1566,7 +1547,7 @@ def sealring_complete_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(tags={"type": "fixed"})
+@gf.cell(tags=["IHP", "sealring"])
 def sealring_corner_CDNS_675179387641_fixed() -> gf.Component:
     """Returns sealring_corner_CDNS_675179387641 fixed cell.
 

--- a/ihp/cells_fixed/__init__.py
+++ b/ihp/cells_fixed/__init__.py
@@ -1001,7 +1001,9 @@ def diodevss_4kv_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_dpantenna_fixed_schematic, tags=["IHP", "diode", "antenna"])
+@gf.cell(
+    schematic_function=_dpantenna_fixed_schematic, tags=["IHP", "diode", "antenna"]
+)
 def dpantenna_fixed() -> gf.Component:
     """Returns dpantenna fixed cell.
 
@@ -1355,7 +1357,9 @@ def ptap1_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_rfcmim_fixed_schematic, tags=["IHP", "capacitor", "mim", "rf"])
+@gf.cell(
+    schematic_function=_rfcmim_fixed_schematic, tags=["IHP", "capacitor", "mim", "rf"]
+)
 def rfcmim_fixed() -> gf.Component:
     """Returns rfcmim fixed cell.
 
@@ -1483,7 +1487,9 @@ def rsil_fixed() -> gf.Component:
 
 
 @deprecated
-@gf.cell(schematic_function=_schottky_nbl1_fixed_schematic, tags=["IHP", "diode", "schottky"])
+@gf.cell(
+    schematic_function=_schottky_nbl1_fixed_schematic, tags=["IHP", "diode", "schottky"]
+)
 def schottky_nbl1_fixed() -> gf.Component:
     """Returns schottky_nbl1 fixed cell.
 


### PR DESCRIPTION
## Summary

- Move taxonomic tags (`["IHP", "resistor", "silicided"]` etc.) out of `s.info["tags"]` inside each `*_schematic()` and onto the corresponding `@gf.cell(tags=...)` decorator — single source of truth per cell.
- Fix the dict-form tags added in #142: `gf.cell`'s signature is `tags: list[str] | None`, and kfactory was silently coercing `tags={"type": "resistors"}` into `{'type'}` (a `set` of the dict's keys).
- Every `@gf.cell` in `ihp/cells/`, `ihp/cells_fixed/`, and `ihp/cells2/` now uses list-form tags starting with `"IHP"`.
- `extract_metadata.py` now reads tags off `kf.kcl.factories[name].tags` (where they actually live) instead of `ds.info`.

## Why

`gf.cell` stores `tags` on the factory (`kf.kcl.factories[name].tags`), not on the schematic or the Component. Two things were wrong:
1. Tags lived in two places — the schematic's `info` dict and the decorator — with two different formats.
2. The decorator value was a dict, which kfactory iterates as a set, so every cell ended up tagged with just `{'type'}`.

Consolidating onto the decorator also lets `gfp2-server` pick tags up via AST parsing without executing Python.

## Test plan

- [x] `uv run pytest` — 714 passed, 14 skipped
- [x] `git grep 'info\["tags"\]' ihp/` → 0 hits
- [x] `git grep 'tags={' ihp/` → 0 hits
- [x] `uv run python extract_metadata.py --csv` → 24 schematic-driven cells with correct taxonomy (e.g. `rsil,resistor,IHP; resistor; silicided,...`)
- [x] Spot-check at runtime: `kf.kcl.factories['rsil'].tags == {'IHP', 'resistor', 'silicided'}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Unify IHP cell taxonomy by consolidating cell tags onto the @gf.cell decorator and aligning them with the actual device types.

New Features:
- Expose richer, device-specific IHP taxonomy tags on all gf.cell-decorated cells for use by metadata consumers.

Bug Fixes:
- Correct previously dict-based gf.cell tags that were silently coerced into incorrect sets, ensuring tags are stored and exposed as intended.

Enhancements:
- Remove redundant per-schematic s.info['tags'] metadata in favor of a single source of truth on the cell decorators.
- Standardize all IHP-related cells to use list-form tags beginning with "IHP" across schematics, fixed cells, and parameterized cells.