### PR TITLE
Add with_ports=True to test_settings

### DIFF
--- a/build_cell.py
+++ b/build_cell.py
@@ -44,7 +44,7 @@ if cell_name == "all_cells":
 
         try:
             c.add_ref(func())
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             print(f"Error instantiating cell {name}: {e}")
     c.write_gds(f"build/gds/{cell_name}.gds")
 else:

--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -92,7 +92,7 @@ def test_gds(component_name: str) -> None:
 def test_settings(component_name: str, data_regression: DataRegressionFixture) -> None:
     """Avoid regressions when exporting settings."""
     component = cells[component_name]()
-    data_regression.check(component.to_dict())
+    data_regression.check(component.to_dict(with_ports=True))
 
 
 skip_test_models = {}

--- a/tests/test_cells/test_settings_add_pads_top_.yml
+++ b/tests/test_cells/test_settings_add_pads_top_.yml
@@ -6,6 +6,25 @@ info:
   route_info_weight: 10
   width: 2
 name: add_pads_top_Cstraight_PNNone_CNNone_CSmetal_routing_PP_c26840c8
+ports:
+  e1:
+    center:
+    - -45
+    - 122.5
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 270
+    port_type: optical
+    width: 45
+  e2:
+    center:
+    - 55
+    - 122.5
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 270
+    port_type: optical
+    width: 45
 settings:
   allow_width_mismatch: true
   bend: wire_corner

--- a/tests/test_cells/test_settings_bend_euler_.yml
+++ b/tests/test_cells/test_settings_bend_euler_.yml
@@ -11,6 +11,25 @@ info:
   route_info_weight: 3.326
   width: 2
 name: bend_euler_RNone_A90_P0p5_WNone_CSstrip_AMRVFalse
+ports:
+  e1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 180
+    port_type: electrical
+    width: 2
+  e2:
+    center:
+    - 2
+    - 2
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 90
+    port_type: electrical
+    width: 2
 settings:
   allow_min_radius_violation: false
   angle: 90

--- a/tests/test_cells/test_settings_bend_metal_.yml
+++ b/tests/test_cells/test_settings_bend_metal_.yml
@@ -10,6 +10,25 @@ info:
   route_info_weight: 3.139
   width: 2
 name: bend_metal_RNone_A90_WNone_CSmetal_routing
+ports:
+  e1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 180
+    port_type: electrical
+    width: 2
+  e2:
+    center:
+    - 2
+    - 2
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 90
+    port_type: electrical
+    width: 2
 settings:
   angle: 90
   cross_section: metal_routing

--- a/tests/test_cells/test_settings_bend_s_.yml
+++ b/tests/test_cells/test_settings_bend_s_.yml
@@ -10,6 +10,25 @@ info:
   route_info_weight: 11.206
   start_angle: 0
 name: bend_s_S11_1p8_CSstrip_WNone_AMRVFalse
+ports:
+  e1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 180
+    port_type: electrical
+    width: 2
+  e2:
+    center:
+    - 11
+    - 1.8
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 0
+    port_type: electrical
+    width: 2
 settings:
   allow_min_radius_violation: false
   cross_section: strip

--- a/tests/test_cells/test_settings_bend_s_metal_.yml
+++ b/tests/test_cells/test_settings_bend_s_metal_.yml
@@ -10,6 +10,25 @@ info:
   route_info_weight: 11.206
   start_angle: 0
 name: bend_s_metal_S11_1p8_CSmetal_routing_WNone_AMRVTrue
+ports:
+  e1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 180
+    port_type: electrical
+    width: 2
+  e2:
+    center:
+    - 11
+    - 1.8
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 0
+    port_type: electrical
+    width: 2
 settings:
   allow_min_radius_violation: true
   cross_section: metal_routing

--- a/tests/test_cells/test_settings_bondpad_.yml
+++ b/tests/test_cells/test_settings_bondpad_.yml
@@ -3,6 +3,16 @@ info:
   shape: octagon
   top_metal: TopMetal2drawing
 name: bondpad_Soctagon_D80_LTMTopMetal2drawing_LTMPTopMetal2p_e907fbed
+ports:
+  pad:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2pin
+    name: pad
+    orientation: 0
+    port_type: electrical
+    width: 80
 settings:
   bbox_offsets:
   - -2.1

--- a/tests/test_cells/test_settings_bondpad_array_.yml
+++ b/tests/test_cells/test_settings_bondpad_array_.yml
@@ -3,6 +3,43 @@ info:
   pad_diameter: 80
   pad_pitch: 100
 name: bondpad_array_NP4_PP100_PD80_Soctagon_LTMTopMetal2drawi_bfd7fae8
+ports:
+  pad_1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2pin
+    name: pad_1
+    orientation: 0
+    port_type: electrical
+    width: 80
+  pad_2:
+    center:
+    - 100
+    - 0
+    layer: TopMetal2pin
+    name: pad_2
+    orientation: 0
+    port_type: electrical
+    width: 80
+  pad_3:
+    center:
+    - 200
+    - 0
+    layer: TopMetal2pin
+    name: pad_3
+    orientation: 0
+    port_type: electrical
+    width: 80
+  pad_4:
+    center:
+    - 300
+    - 0
+    layer: TopMetal2pin
+    name: pad_4
+    orientation: 0
+    port_type: electrical
+    width: 80
 settings:
   bbox_offsets:
   - -2.1

--- a/tests/test_cells/test_settings_cmim_.yml
+++ b/tests/test_cells/test_settings_cmim_.yml
@@ -5,6 +5,25 @@ info:
   model: cmim
   width: 6
 name: cmim_W6_L6_LMMetal5drawing_LMMIMdrawing_LVVmimdrawing_L_8b51f9e9
+ports:
+  MINUS:
+    center:
+    - -3.86
+    - 0
+    layer: Metal5pin
+    name: MINUS
+    orientation: 180
+    port_type: electrical
+    width: 0.2
+  PLUS:
+    center:
+    - 2.5
+    - 0
+    layer: TopMetal1pin
+    name: PLUS
+    orientation: 0
+    port_type: electrical
+    width: 1
 settings:
   layer_cap_mark: MemCapdrawing
   layer_m4nofill: Metal4nofill

--- a/tests/test_cells/test_settings_cmom_.yml
+++ b/tests/test_cells/test_settings_cmom_.yml
@@ -5,6 +5,25 @@ info:
   nfingers: 1
   spacing: 0.26
 name: cmom_N1_L4_S0p26_BMetal1_TMetal3_LMMetal1drawing_LMMeta_e389502b
+ports:
+  MINUS:
+    center:
+    - 0.47
+    - -0.21
+    layer: Metal3pin
+    name: MINUS
+    orientation: 0
+    port_type: electrical
+    width: 0.14
+  PLUS:
+    center:
+    - 0.47
+    - 4.47
+    layer: Metal3pin
+    name: PLUS
+    orientation: 0
+    port_type: electrical
+    width: 0.14
 settings:
   botmetal: Metal1
   layer_cap_mark: MemCapdrawing

--- a/tests/test_cells/test_settings_dantenna_.yml
+++ b/tests/test_cells/test_settings_dantenna_.yml
@@ -1,5 +1,6 @@
 info: {}
 name: dantenna_W0p78_L0p78_At_Gnone_G1
+ports: {}
 settings:
   addRecLayer: t
   guardRingDistance: 1

--- a/tests/test_cells/test_settings_dpantenna_.yml
+++ b/tests/test_cells/test_settings_dpantenna_.yml
@@ -1,5 +1,6 @@
 info: {}
 name: dpantenna_W0p78_L0p78_At_Gnone_G1
+ports: {}
 settings:
   addRecLayer: t
   guardRingDistance: 1

--- a/tests/test_cells/test_settings_esd_nmos_.yml
+++ b/tests/test_cells/test_settings_esd_nmos_.yml
@@ -1,5 +1,24 @@
 info: {}
 name: esd_nmos_W50_L0p5_N10_Mnmoscl_2_LPPWelldrawing_LAActivd_f58b4bf2
+ports:
+  GND:
+    center:
+    - 0
+    - -2.5
+    layer: Metal1pin
+    name: GND
+    orientation: 270
+    port_type: electrical
+    width: 16
+  PAD:
+    center:
+    - 0
+    - 4
+    layer: Metal2pin
+    name: PAD
+    orientation: 90
+    port_type: electrical
+    width: 16
 settings:
   layer_activ: Activdrawing
   layer_cont: Contdrawing

--- a/tests/test_cells/test_settings_inductor2_.yml
+++ b/tests/test_cells/test_settings_inductor2_.yml
@@ -7,6 +7,25 @@ info:
   turns: 1
   width: 2
 name: inductor2_W2_S2p1_D25p35_VW0p9_R0p5777_I3p3303em11_T1L3_b7ab4e17
+ports:
+  P1:
+    center:
+    - -2.05
+    - 0
+    layer: TopMetal2pin
+    name: P1
+    orientation: 270
+    port_type: electrical
+    width: 2
+  P2:
+    center:
+    - 2.05
+    - 0
+    layer: TopMetal2pin
+    name: P2
+    orientation: 270
+    port_type: electrical
+    width: 2
 settings:
   diameter: 25.35
   inductance: 0.0

--- a/tests/test_cells/test_settings_inductor3_.yml
+++ b/tests/test_cells/test_settings_inductor3_.yml
@@ -7,6 +7,34 @@ info:
   turns: 2
   width: 2
 name: inductor3_W2_S2p1_D25p84_VW0p9_R1p386_I2p215em1_T1L30_T_def811cb
+ports:
+  P1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2pin
+    name: P1
+    orientation: 270
+    port_type: electrical
+    width: 2
+  P2:
+    center:
+    - -4.1
+    - 0
+    layer: TopMetal1pin
+    name: P2
+    orientation: 270
+    port_type: electrical
+    width: 2
+  P3:
+    center:
+    - 4.1
+    - 0
+    layer: TopMetal1pin
+    name: P3
+    orientation: 270
+    port_type: electrical
+    width: 2
 settings:
   diameter: 25.84
   inductance: 0.0

--- a/tests/test_cells/test_settings_nmos_.yml
+++ b/tests/test_cells/test_settings_nmos_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: nmos_W0p15_L0p13_N1_M1_Msg13_lv_nmos
+ports:
+  D:
+    center:
+    - 0.72
+    - 0.15
+    layer: Metal1pin
+    name: D
+    orientation: 0
+    port_type: electrical
+    width: 0.26
+  G:
+    center:
+    - 0.435
+    - 0.15
+    layer: GatPolypin
+    name: G
+    orientation: 270
+    port_type: electrical
+    width: 0.51
+  S:
+    center:
+    - 0.15
+    - 0.15
+    layer: Metal1pin
+    name: S
+    orientation: 180
+    port_type: electrical
+    width: 0.26
 settings:
   length: 0.13
   m: 1

--- a/tests/test_cells/test_settings_nmos_hv_.yml
+++ b/tests/test_cells/test_settings_nmos_hv_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: nmos_hv_W0p6_L0p45_N1_M1_Msg13_hv_nmos
+ports:
+  D:
+    center:
+    - 0.98
+    - 0.3
+    layer: Metal1pin
+    name: D
+    orientation: 0
+    port_type: electrical
+    width: 0.6
+  G:
+    center:
+    - 0.565
+    - 0.3
+    layer: GatPolypin
+    name: G
+    orientation: 270
+    port_type: electrical
+    width: 0.96
+  S:
+    center:
+    - 0.15
+    - 0.3
+    layer: Metal1pin
+    name: S
+    orientation: 180
+    port_type: electrical
+    width: 0.6
 settings:
   length: 0.45
   m: 1

--- a/tests/test_cells/test_settings_npn13G2L_.yml
+++ b/tests/test_cells/test_settings_npn13G2L_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: npn13G2L_EL1_EW0p07_N1
+ports:
+  B:
+    center:
+    - 3.9
+    - 1.775
+    layer: Metal1pin
+    name: B
+    orientation: 180
+    port_type: electrical
+    width: 0.65
+  C:
+    center:
+    - 3.9
+    - 5.425
+    layer: Metal1pin
+    name: C
+    orientation: 180
+    port_type: electrical
+    width: 0.65
+  E:
+    center:
+    - 3.9
+    - 3.6
+    layer: Metal2pin
+    name: E
+    orientation: 180
+    port_type: electrical
+    width: 1.4
 settings:
   Nx: 1
   emitter_length: 1

--- a/tests/test_cells/test_settings_npn13G2V_.yml
+++ b/tests/test_cells/test_settings_npn13G2V_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: npn13G2V_EL1_EW0p12_N1
+ports:
+  B:
+    center:
+    - 3.87
+    - 1.775
+    layer: Metal1pin
+    name: B
+    orientation: 180
+    port_type: electrical
+    width: 0.65
+  C:
+    center:
+    - 3.87
+    - 5.425
+    layer: Metal1pin
+    name: C
+    orientation: 180
+    port_type: electrical
+    width: 0.65
+  E:
+    center:
+    - 3.87
+    - 3.6
+    layer: Metal2pin
+    name: E
+    orientation: 180
+    port_type: electrical
+    width: 1.4
 settings:
   Nx: 1
   emitter_length: 1

--- a/tests/test_cells/test_settings_npn13G2_.yml
+++ b/tests/test_cells/test_settings_npn13G2_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: npn13G2_B0p3_B0p07_B0p1_E0p15_E0p18_S0p44_EL0p9_EW0p7_N_5249a3d6
+ports:
+  B:
+    center:
+    - 0
+    - -1.14
+    layer: Metal1pin
+    name: B
+    orientation: 180
+    port_type: electrical
+    width: 0.24
+  C:
+    center:
+    - 0
+    - 1.13
+    layer: Metal1pin
+    name: C
+    orientation: 180
+    port_type: electrical
+    width: 0.24
+  E:
+    center:
+    - 0
+    - -0.008
+    layer: Metal2pin
+    name: E
+    orientation: 180
+    port_type: electrical
+    width: 1.556
 settings:
   CMetY1: 0
   CMetY2: 0

--- a/tests/test_cells/test_settings_ntap1_.yml
+++ b/tests/test_cells/test_settings_ntap1_.yml
@@ -5,6 +5,16 @@ info:
   type: ntap
   width: 1
 name: ntap1_W1_L1_R1_C1_LNNWelldrawing_LAActivdrawing_LNnSDdr_9ff6c456
+ports:
+  TAP:
+    center:
+    - 0
+    - 0
+    layer: Metal1pin
+    name: TAP
+    orientation: 0
+    port_type: electrical
+    width: 1
 settings:
   cols: 1
   layer_activ: Activdrawing

--- a/tests/test_cells/test_settings_pmos_.yml
+++ b/tests/test_cells/test_settings_pmos_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: pmos_W0p15_L0p13_N1_M1_Msg13_lv_pmos
+ports:
+  D:
+    center:
+    - 0.72
+    - 0.15
+    layer: Metal1pin
+    name: D
+    orientation: 0
+    port_type: electrical
+    width: 0.26
+  G:
+    center:
+    - 0.435
+    - 0.15
+    layer: GatPolypin
+    name: G
+    orientation: 270
+    port_type: electrical
+    width: 0.51
+  S:
+    center:
+    - 0.15
+    - 0.15
+    layer: Metal1pin
+    name: S
+    orientation: 180
+    port_type: electrical
+    width: 0.26
 settings:
   length: 0.13
   m: 1

--- a/tests/test_cells/test_settings_pmos_hv_.yml
+++ b/tests/test_cells/test_settings_pmos_hv_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: pmos_hv_W0p3_L0p4_N1_M1_Msg13_hv_pmos
+ports:
+  D:
+    center:
+    - 0.93
+    - 0.15
+    layer: Metal1pin
+    name: D
+    orientation: 0
+    port_type: electrical
+    width: 0.3
+  G:
+    center:
+    - 0.54
+    - 0.15
+    layer: GatPolypin
+    name: G
+    orientation: 270
+    port_type: electrical
+    width: 0.66
+  S:
+    center:
+    - 0.15
+    - 0.15
+    layer: Metal1pin
+    name: S
+    orientation: 180
+    port_type: electrical
+    width: 0.3
 settings:
   length: 0.4
   m: 1

--- a/tests/test_cells/test_settings_pnpMPA_.yml
+++ b/tests/test_cells/test_settings_pnpMPA_.yml
@@ -1,5 +1,33 @@
 info: {}
 name: pnpMPA_L2_W0p7
+ports:
+  MINUS:
+    center:
+    - -0.915
+    - 0
+    layer: Metal1pin
+    name: MINUS
+    orientation: 270
+    port_type: electrical
+    width: 0.31
+  PLUS:
+    center:
+    - 0
+    - 0
+    layer: Metal1pin
+    name: PLUS
+    orientation: 270
+    port_type: electrical
+    width: 0.66
+  TIE:
+    center:
+    - 0
+    - 2.835
+    layer: Metal1pin
+    name: TIE
+    orientation: 180
+    port_type: electrical
+    width: 0.35
 settings:
   length: 2
   width: 0.7

--- a/tests/test_cells/test_settings_ptap1_.yml
+++ b/tests/test_cells/test_settings_ptap1_.yml
@@ -5,6 +5,16 @@ info:
   type: ptap
   width: 1
 name: ptap1_W1_L1_R1_C1_LAActivdrawing_LPpSDdrawing_LCContdra_b14a891f
+ports:
+  TAP:
+    center:
+    - 0
+    - 0
+    layer: Metal1pin
+    name: TAP
+    orientation: 0
+    port_type: electrical
+    width: 1
 settings:
   cols: 1
   layer_activ: Activdrawing

--- a/tests/test_cells/test_settings_rfcmim_.yml
+++ b/tests/test_cells/test_settings_rfcmim_.yml
@@ -5,6 +5,34 @@ info:
   model: cap_rfcmim
   width: 7
 name: rfcmim_W7_L7_LPPWellblock_LMMetal5drawing_LMMIMdrawing__5095ef1b
+ports:
+  MINUS:
+    center:
+    - -4.36
+    - 0
+    layer: Metal5pin
+    name: MINUS
+    orientation: 180
+    port_type: electrical
+    width: 0.2
+  PLUS:
+    center:
+    - 3
+    - 0
+    layer: TopMetal1pin
+    name: PLUS
+    orientation: 0
+    port_type: electrical
+    width: 1
+  TIE_LOW:
+    center:
+    - 0
+    - -8.46
+    layer: Metal1pin
+    name: TIE_LOW
+    orientation: 0
+    port_type: electrical
+    width: 2
 settings:
   layer_activ: Activdrawing
   layer_activnoqrc: Activnoqrc

--- a/tests/test_cells/test_settings_rfnmos_.yml
+++ b/tests/test_cells/test_settings_rfnmos_.yml
@@ -1,5 +1,42 @@
 info: {}
 name: rfnmos_W1_L0p13_N1_M1_CR1_MCTrue_GRTrue_GRYes_Msg13_lv_nmos
+ports:
+  D:
+    center:
+    - 1.64
+    - 1.92
+    layer: Metal1pin
+    name: D
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  G:
+    center:
+    - 0.86
+    - 1.66
+    layer: Metal1pin
+    name: G
+    orientation: 180
+    port_type: electrical
+    width: 0.64
+  S:
+    center:
+    - 1.64
+    - 1.4
+    layer: Metal1pin
+    name: S
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  TIE:
+    center:
+    - 1.64
+    - 0.19
+    layer: Metal1pin
+    name: TIE
+    orientation: 270
+    port_type: electrical
+    width: 0.16
 settings:
   cnt_rows: 1
   gat_ring: true

--- a/tests/test_cells/test_settings_rfnmos_hv_.yml
+++ b/tests/test_cells/test_settings_rfnmos_hv_.yml
@@ -1,5 +1,42 @@
 info: {}
 name: rfnmos_hv_W1_L0p45_N1_M1_CR1_MCTrue_GRTrue_GRYes_Msg13_hv_nmos
+ports:
+  D:
+    center:
+    - 1.99
+    - 2.58
+    layer: Metal1pin
+    name: D
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  G:
+    center:
+    - 1.21
+    - 2.165
+    layer: Metal1pin
+    name: G
+    orientation: 180
+    port_type: electrical
+    width: 0.95
+  S:
+    center:
+    - 1.99
+    - 1.75
+    layer: Metal1pin
+    name: S
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  TIE:
+    center:
+    - 1.99
+    - 0.54
+    layer: Metal1pin
+    name: TIE
+    orientation: 270
+    port_type: electrical
+    width: 0.16
 settings:
   cnt_rows: 1
   gat_ring: true

--- a/tests/test_cells/test_settings_rfpmos_.yml
+++ b/tests/test_cells/test_settings_rfpmos_.yml
@@ -1,5 +1,42 @@
 info: {}
 name: rfpmos_W1_L0p13_N1_M1_CR1_MCTrue_GRTrue_GRYes_Msg13_lv_pmos
+ports:
+  D:
+    center:
+    - 1.92
+    - 2.2
+    layer: Metal1pin
+    name: D
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  G:
+    center:
+    - 1.14
+    - 1.94
+    layer: Metal1pin
+    name: G
+    orientation: 180
+    port_type: electrical
+    width: 0.64
+  S:
+    center:
+    - 1.92
+    - 1.68
+    layer: Metal1pin
+    name: S
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  TIE:
+    center:
+    - 1.92
+    - 0.47
+    layer: Metal1pin
+    name: TIE
+    orientation: 270
+    port_type: electrical
+    width: 0.16
 settings:
   cnt_rows: 1
   gat_ring: true

--- a/tests/test_cells/test_settings_rfpmos_hv_.yml
+++ b/tests/test_cells/test_settings_rfpmos_hv_.yml
@@ -1,5 +1,42 @@
 info: {}
 name: rfpmos_hv_W1_L0p4_N1_M1_CR1_MCTrue_GRTrue_GRYes_Msg13_hv_pmos
+ports:
+  D:
+    center:
+    - 2.27
+    - 2.81
+    layer: Metal1pin
+    name: D
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  G:
+    center:
+    - 1.49
+    - 2.42
+    layer: Metal1pin
+    name: G
+    orientation: 180
+    port_type: electrical
+    width: 0.9
+  S:
+    center:
+    - 2.27
+    - 2.03
+    layer: Metal1pin
+    name: S
+    orientation: 270
+    port_type: electrical
+    width: 0.9
+  TIE:
+    center:
+    - 2.27
+    - 0.82
+    layer: Metal1pin
+    name: TIE
+    orientation: 270
+    port_type: electrical
+    width: 0.16
 settings:
   cnt_rows: 1
   gat_ring: true

--- a/tests/test_cells/test_settings_rhigh_.yml
+++ b/tests/test_cells/test_settings_rhigh_.yml
@@ -6,6 +6,25 @@ info:
   resistance: 576
   sheet_resistance: 300
 name: rhigh_D0p96_D0p5_RNone_Mrhigh_LPPolyResdrawing_LHHeatRe_f86e6d72
+ports:
+  P1:
+    center:
+    - 0.25
+    - 1.24
+    layer: Metal1pin
+    name: P1
+    orientation: 90
+    port_type: electrical
+    width: 0.46
+  P2:
+    center:
+    - 0.25
+    - -0.28
+    layer: Metal1pin
+    name: P2
+    orientation: 270
+    port_type: electrical
+    width: 0.46
 settings:
   dx: 0.5
   dy: 0.96

--- a/tests/test_cells/test_settings_rppd_.yml
+++ b/tests/test_cells/test_settings_rppd_.yml
@@ -6,6 +6,25 @@ info:
   resistance: 300
   sheet_resistance: 300
 name: rppd_D0p5_D0p5_RNone_Mrppd_LPPolyResdrawing_LHHeatResdr_f26b8519
+ports:
+  P1:
+    center:
+    - 0.25
+    - 0.78
+    layer: Metal1pin
+    name: P1
+    orientation: 90
+    port_type: electrical
+    width: 0.46
+  P2:
+    center:
+    - 0.25
+    - -0.28
+    layer: Metal1pin
+    name: P2
+    orientation: 270
+    port_type: electrical
+    width: 0.46
 settings:
   dx: 0.5
   dy: 0.5

--- a/tests/test_cells/test_settings_rsil_.yml
+++ b/tests/test_cells/test_settings_rsil_.yml
@@ -6,6 +6,25 @@ info:
   resistance: 7
   sheet_resistance: 7
 name: rsil_D0p5_D0p5_RNone_Mrsil_LPPolyResdrawing_LHHeatResdr_0d134d2b
+ports:
+  P1:
+    center:
+    - 0.25
+    - 0.7
+    layer: Metal1pin
+    name: P1
+    orientation: 90
+    port_type: electrical
+    width: 0.46
+  P2:
+    center:
+    - 0.25
+    - -0.2
+    layer: Metal1pin
+    name: P2
+    orientation: 270
+    port_type: electrical
+    width: 0.46
 settings:
   dx: 0.5
   dy: 0.5

--- a/tests/test_cells/test_settings_sealring_.yml
+++ b/tests/test_cells/test_settings_sealring_.yml
@@ -4,6 +4,7 @@ info:
   type: sealring
   width: 200
 name: sealring_W200_H200_RW5_LMMetal1drawing_LMMetal2drawing__b3748dda
+ports: {}
 settings:
   height: 200
   layer_metal1: Metal1drawing

--- a/tests/test_cells/test_settings_straight_.yml
+++ b/tests/test_cells/test_settings_straight_.yml
@@ -6,6 +6,25 @@ info:
   route_info_weight: 10
   width: 2
 name: straight_L10_CSstrip_WNone_N2
+ports:
+  e1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 180
+    port_type: electrical
+    width: 2
+  e2:
+    center:
+    - 10
+    - 0
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 0
+    port_type: electrical
+    width: 2
 settings:
   cross_section: strip
   length: 10

--- a/tests/test_cells/test_settings_straight_metal_.yml
+++ b/tests/test_cells/test_settings_straight_metal_.yml
@@ -6,6 +6,25 @@ info:
   route_info_weight: 10
   width: 2
 name: straight_metal_L10_CSmetal_routing_WNone
+ports:
+  e1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 180
+    port_type: electrical
+    width: 2
+  e2:
+    center:
+    - 10
+    - 0
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 0
+    port_type: electrical
+    width: 2
 settings:
   cross_section: metal_routing
   length: 10

--- a/tests/test_cells/test_settings_text_rectangular_.yml
+++ b/tests/test_cells/test_settings_text_rectangular_.yml
@@ -1,5 +1,6 @@
 info: {}
 name: text_rectangular_Tabc_S3_Jleft_LTopMetal2drawing
+ports: {}
 settings:
   justify: left
   layer: TopMetal2drawing

--- a/tests/test_cells/test_settings_text_rectangular_multi_layer_.yml
+++ b/tests/test_cells/test_settings_text_rectangular_multi_layer_.yml
@@ -1,5 +1,6 @@
 info: {}
 name: text_rectangular_multi_layer_Tabc_LTopMetal2drawing_TFt_a1dc3a72
+ports: {}
 settings:
   layers:
   - TopMetal2drawing

--- a/tests/test_cells/test_settings_via_array_.yml
+++ b/tests/test_cells/test_settings_via_array_.yml
@@ -7,6 +7,7 @@ info:
   rows: 2
   via_type: Via1
 name: via_array_VTVia1_C2_R2_VSNone_VSNone_VENone_LCContdrawi_5baa5773
+ports: {}
 settings:
   columns: 2
   layer_cont: Contdrawing

--- a/tests/test_cells/test_settings_via_stack_.yml
+++ b/tests/test_cells/test_settings_via_stack_.yml
@@ -5,6 +5,25 @@ info:
   top_layer: Metal2
   width: 10
 name: via_stack_BLMetal1_TLMetal2_S10_10_VC2_VR2_VC1_VR1_VC1__fd26eaf7
+ports:
+  bottom:
+    center:
+    - 0
+    - 0
+    layer: Metal1pin
+    name: bottom
+    orientation: 0
+    port_type: electrical
+    width: 10
+  top:
+    center:
+    - 0
+    - 0
+    layer: Metal2pin
+    name: top
+    orientation: 0
+    port_type: electrical
+    width: 10
 settings:
   bottom_layer: Metal1
   layer_activ: Activdrawing

--- a/tests/test_cells/test_settings_wire_corner45_.yml
+++ b/tests/test_cells/test_settings_wire_corner45_.yml
@@ -1,6 +1,25 @@
 info:
   length: 14.142
 name: wire_corner45_CSmetal_routing_R10_WNone_LNone_WCPTrue
+ports:
+  e1:
+    center:
+    - 0
+    - 0
+    layer: TopMetal2drawing
+    name: e1
+    orientation: 180
+    port_type: electrical
+    width: 2
+  e2:
+    center:
+    - 10
+    - 10
+    layer: TopMetal2drawing
+    name: e2
+    orientation: 90
+    port_type: electrical
+    width: 2
 settings:
   cross_section: metal_routing
   radius: 10


### PR DESCRIPTION
## Summary
- Add `with_ports=True` to `test_settings` `to_dict()` call to catch port naming and position regressions
- Regenerated regression data files with port information included

## Test plan
- [x] `pytest tests/test_cells.py::test_settings` passes (40 passed)

## Summary by Sourcery

Tests:
- Update cell settings regression fixtures to store each component's port metadata, including empty port maps where applicable.