### PR TITLE
feat: enable sbend="bend_s" in route_bundle strategies

### DIFF
--- a/ihp-gdsfactory--sample-projects/ihp--public--project/ihp/tech.py
+++ b/ihp-gdsfactory--sample-projects/ihp--public--project/ihp/tech.py
@@ -494,7 +494,7 @@ cross_sections = get_cross_sections(sys.modules[__name__])
 # Routing functions
 ############################
 
-route_bundle = partial(gf.routing.route_bundle, cross_section="strip")
+route_bundle = partial(gf.routing.route_bundle, cross_section="strip", sbend="bend_s")
 route_bundle_rib = partial(
     route_bundle,
     cross_section="rib",

--- a/ihp/tech.py
+++ b/ihp/tech.py
@@ -1152,7 +1152,7 @@ cross_sections = get_cross_sections(sys.modules[__name__])
 # Routing functions
 ############################
 
-route_bundle = partial(gf.routing.route_bundle, cross_section="strip")
+route_bundle = partial(gf.routing.route_bundle, cross_section="strip", sbend="bend_s")
 route_bundle_rib = partial(
     route_bundle,
     cross_section="rib",


### PR DESCRIPTION
## Summary

- Enable `sbend="bend_s"` in all `route_bundle` routing strategies
- This allows the router to use S-bends when needed to avoid collisions

## Test plan

- [ ] Verify routing still works correctly with sbend enabled

## Summary by Sourcery

New Features:
- Allow specifying S-bend geometry via sbend="bend_s" in the default strip route_bundle configuration used across the tech files.