### PR TITLE
Add zensical docs support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,22 @@ gmsh:
 docs-clean: gmsh
 	rm -rf docs/_build
 
-docs: docs-clean
-	uv run python .github/write_cells.py
-	uv run jb build docs
-
-docs-serve: docs
-	python -m http.server -d docs/_build/html 8000
-
 mask:
 	python ubcpdk/samples/test_masks.py
 
-.PHONY: drc doc docs docs-clean docs-serve install build
+docs-pdf:
+	uv run python .github/write_cells.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run mkdocs build -f mkdocs-pdf.yml
+
+docs:
+	uv run python .github/write_cells.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical build
+
+docs-serve:
+	uv run python .github/write_cells.py
+	cp CHANGELOG.md docs/changelog.md
+	uv run --extra docs zensical serve -a localhost:8080
+
+.PHONY: drc drc-sample doc docs docs-pdf build

--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,54 @@
+# ruff: noqa: INP001
+"""Post-process notebook markdown: convert MyST admonitions to Material style.
+
+Usage: python docs/hooks.py docs/notebooks/*.md
+"""
+
+import re
+import sys
+from pathlib import Path
+
+
+def process(markdown: str) -> str:
+    """Apply all transformations to a markdown string."""
+    return _myst_to_material_admonitions(markdown)
+
+
+def _myst_to_material_admonitions(markdown: str) -> str:
+    r"""Convert MyST ```{type}\n...\n``` to Material !!! type\n\n    ..."""
+
+    def _replace(match: re.Match[str]) -> str:
+        kind = match.group(1)
+        body = match.group(2)
+        lines = body.splitlines()
+        title = ""
+        while lines and not lines[0].strip():
+            lines.pop(0)
+        if lines and (m := re.match(r"^#+ +(.+)", lines[0])):
+            title = m.group(1)
+            lines.pop(0)
+        non_empty = [line for line in lines if line.strip()]
+        min_indent = min(
+            (len(line) - len(line.lstrip()) for line in non_empty), default=0
+        )
+        out = []
+        for line in lines:
+            if line.strip():
+                out.append("    " + line[min_indent:])
+            else:
+                out.append("")
+        header = f'!!! {kind} "{title}"' if title else f"!!! {kind}"
+        return header + "\n\n" + "\n".join(out).rstrip() + "\n"
+
+    return re.sub(
+        r"^```\{(\w+)\}\s*\n(.*?)^```\s*$",
+        _replace,
+        markdown,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+
+
+if __name__ == "__main__":
+    for path in sys.argv[1:]:
+        p = Path(path)
+        p.write_text(process(p.read_text()))

--- a/docs/palace_demo_cpw.ipynb
+++ b/docs/palace_demo_cpw.ipynb
@@ -32,6 +32,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
+    "\n",
     "from ihp import LAYER, PDK\n",
     "\n",
     "PDK.activate()\n",

--- a/docs/palace_demo_microstrip.ipynb
+++ b/docs/palace_demo_microstrip.ipynb
@@ -32,6 +32,7 @@
    "outputs": [],
    "source": [
     "import gdsfactory as gf\n",
+    "\n",
     "from ihp import LAYER, PDK, cells\n",
     "\n",
     "PDK.activate()\n",

--- a/mkdocs-pdf.yml
+++ b/mkdocs-pdf.yml
@@ -1,0 +1,24 @@
+site_name: IHP pdk
+docs_dir: docs
+site_dir: build/pdf
+nav:
+  - Home: index.md
+  - Reference:
+      - Changelog: changelog.md
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_root_toc_entry: false
+            show_source: false
+  - with-pdf:
+      author: GDSFactory
+      cover_subtitle: Photonics Process Design Kit
+      output_path: ../../docs.pdf
+theme:
+  name: material
+  logo: logo.png

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,14 @@ dev = [
   "pytest-github-actions-annotate-failures",
   "pre-commit"
 ]
-docs = ["autodoc_pydantic", "jupytext", "jupyter-book==1.0.3"]
+docs = [
+  "jupyter",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "nbconvert",
+  "mkdocstrings[python]>=0.27.0",
+  "zensical>=0.0.40,<0.1.0"
+]
 simulation = ["gsim>=0.0.8; python_version>='3.12'"]
 
 [tool.codespell]

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,27 @@
+[project]
+nav = [
+  {"Home" = "index.md"},
+  {"Reference" = [
+    {"Changelog" = "changelog.md"}
+  ]}
+]
+site_dir = "docs/_build/html"
+site_name = "IHP pdk"
+site_url = "https://gdsfactory.github.io/ihp"
+
+[project.plugins.autorefs]
+
+[project.plugins.mkdocstrings]
+
+[project.plugins.mkdocstrings.handlers.python]
+
+[project.plugins.mkdocstrings.handlers.python.options]
+docstring_style = "google"
+show_root_toc_entry = false
+show_source = false
+
+[project.plugins.search]
+
+[project.theme]
+logo = "logo.png"
+name = "material"


### PR DESCRIPTION
## Summary
- Switch documentation to zensical (Material theme) with mkdocs-pdf support
- Update Makefile with `docs`, `docs-serve`, and `docs-pdf` targets

## Test plan
- [ ] `make docs` builds HTML documentation
- [ ] `make docs-pdf` generates PDF

## Summary by Sourcery

Switch project documentation to use the Zensical/Material-based mkdocs setup with HTML and PDF builds and integrate it into the existing docs Makefile flow.

New Features:
- Add Zensical- and mkdocs-based HTML and PDF documentation generation, including a Material theme configuration.
- Introduce a post-processing hook to convert MyST-style admonitions in notebook markdown to Material-style admonitions.

Enhancements:
- Update Makefile targets to build, serve, and generate PDF documentation via the new Zensical/mkdocs pipeline and reuse the changelog content in docs.
- Adjust documentation extras in pyproject.toml to depend on mkdocs, Zensical, and related plugins instead of the previous jupyter-book setup.

Documentation:
- Add Zensical and mkdocs configuration files to define site navigation, theme, plugins, and PDF output for the project documentation.