### PR TITLE
feat: add Makefile target to test sample projects with gfp test

### DIFF
--- a/.github/workflows/sample-projects.yml
+++ b/.github/workflows/sample-projects.yml
@@ -1,0 +1,14 @@
+name: Test Sample Projects
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths: ['*--sample-projects/**']
+  pull_request:
+    paths: ['*--sample-projects/**']
+
+jobs:
+  test-sample-projects:
+    uses: doplaydo/pdk-ci-workflow/.github/workflows/test-sample-projects.yml@main
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ test:
 test-force: install
 	uv run pytest -s --force-regen
 
+test-gfp-projects:
+	cd ihp-gdsfactory--sample-projects/ihp--public--project && uv run --directory $(CURDIR) gfp test
+
 git-rm-merged:
 	git branch -D `git branch --merged | grep -v \* | xargs`
 


### PR DESCRIPTION
## Summary

- Add `test-gfp-projects` Makefile target that runs `gfp test` inside each sample project
- Ensures all cells in sample projects are tested

**Sample projects tested:**
  - `ihp-gdsfactory--sample-projects/ihp--public--project`

**Usage:**
```bash
make test-gfp-projects
```

## Test plan
- [ ] Run `make test-gfp-projects` and verify all tests pass

## Summary by Sourcery

New Features:
- Introduce a test-gfp-projects Makefile target that executes gfp test within the ihp public sample project.