### PR TITLE
add update-changelog Makefile target

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,7 @@ docs-serve:
 	cp CHANGELOG.md docs/changelog.md
 	uv run --extra docs zensical serve -f docs/zensical.toml -a localhost:8080
 
-.PHONY: drc drc-sample doc docs docs-pdf build
+update-changelog:
+	claude -p "remove links and make a user friendly changelog from @CHANGELOG.md to @docs/changelog.md"
+
+.PHONY: drc drc-sample doc docs docs-pdf build update-changelog


### PR DESCRIPTION
## Summary
- Add `update-changelog` Makefile target that uses Claude to generate a user-friendly changelog from CHANGELOG.md to docs/changelog.md

## Test plan
- [ ] Run `make update-changelog` to verify it works

## Summary by Sourcery

Add a Makefile target to regenerate a user-friendly docs changelog using Claude and introduce a configuration file for Claude agents.

New Features:
- Introduce an update-changelog Makefile target to generate docs/changelog.md from CHANGELOG.md using Claude.

Build:
- Extend the Makefile phony targets list to include update-changelog.

Documentation:
- Add CLAUDE.md to reference the Claude agents configuration file.