### PR TITLE
Add --verbose flag to twine upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,4 +21,4 @@ jobs:
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
           make build
-          twine upload dist/*
+          twine upload --verbose dist/*


### PR DESCRIPTION
## Summary
- Adds --verbose flag to twine upload commands in the release workflow for better upload diagnostics.

Closes #192

## Test plan
- [ ] Trigger a release workflow run and verify twine outputs verbose logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Build:
- Enable Twine verbose mode in the release GitHub Actions workflow to improve upload diagnostics.