### PR TITLE
fix: correct pre-commit instructions and add tests section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # IHP GDSFactory PDK
 
-IHP's SG13G2 is an open-source 130nm SiGe BiCMOS technology for RF/mmWave electronics — the fleet's only all-electronic, non-photonic process.
+IHP's SG13G2 is an open-source 130nm SiGe BiCMOS technology for RF/mmWave electronics.
 
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/ihp/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/ihp/actions/workflows/pages.yml)
@@ -166,18 +166,10 @@ uv run pytest tests/test_xor_transistors.py -v # polygon-exact XOR vs PyCell
 
 ## Pre-commit
 
-Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow-public](https://github.com/doplaydo/pdk-ci-workflow-public). `make dev` fetches the canonical config and installs the git hook.
 
 ```bash
 make dev
-```
-
-## Tests
-
-Run the test suite:
-
-```bash
-make test
 ```
 
 ## Release

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # IHP GDSFactory PDK
 
+IHP's SG13G2 is an open-source 130nm SiGe BiCMOS technology for RF/mmWave electronics — the fleet's only all-electronic, non-photonic process.
+
 <!-- BADGES:START -->
 [![Docs](https://github.com/gdsfactory/ihp/actions/workflows/pages.yml/badge.svg)](https://github.com/gdsfactory/ihp/actions/workflows/pages.yml)
 [![Tests](https://github.com/gdsfactory/ihp/actions/workflows/test_code.yml/badge.svg)](https://github.com/gdsfactory/ihp/actions/workflows/test_code.yml)

--- a/README.md
+++ b/README.md
@@ -164,8 +164,18 @@ uv run pytest tests/test_xor_transistors.py -v # polygon-exact XOR vs PyCell
 
 ## Pre-commit
 
+Pre-commit hooks are centrally maintained in [pdk-ci-workflow](https://github.com/doplaydo/pdk-ci-workflow). `make dev` fetches the canonical config and installs the git hook.
+
 ```bash
-make pre-commit
+make dev
+```
+
+## Tests
+
+Run the test suite:
+
+```bash
+make test
 ```
 
 ## Release


### PR DESCRIPTION
The Makefile's pre-commit setup target is `dev` (fetches the canonical config from pdk-ci-workflow), not `make pre-commit`. This updates the README to match, and adds a missing `## Tests` section documenting `make test`.

Part of doplaydo/pdks#49.

## Summary by Sourcery

Document pre-commit setup and test execution workflow in the README.

Documentation:
- Update pre-commit instructions to reference the centrally managed hooks and the `make dev` setup target.
- Add a dedicated Tests section describing how to run the test suite via `make test`.