### PR TITLE
feat(livewire): set schematic_scale = 0.1 for IHP

### DIFF
--- a/ihp-gdsfactory--sample-projects/ihp--public--project/pyproject.toml
+++ b/ihp-gdsfactory--sample-projects/ihp--public--project/pyproject.toml
@@ -50,6 +50,9 @@ ignore-words-list = "te,fpr,nd,donot,schem"
 name = "ihp"
 pdk.name = "ihp"
 
+[tool.gdsfactoryplus.livewire]
+schematic_scale = 0.1
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/ihp-gdsfactory--sample-projects/ihp--public--project/pyproject.toml
+++ b/ihp-gdsfactory--sample-projects/ihp--public--project/pyproject.toml
@@ -48,10 +48,12 @@ ignore-words-list = "te,fpr,nd,donot,schem"
 
 [tool.gdsfactoryplus]
 name = "ihp"
-pdk.name = "ihp"
 
 [tool.gdsfactoryplus.livewire]
 schematic_scale = 0.1
+
+[tool.gdsfactoryplus.pdk]
+name = "ihp"
 
 [tool.mypy]
 python_version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,9 @@ name = "ihp"
 [tool.gdsfactoryplus.pdk]
 name = "ihp"
 
+[tool.gdsfactoryplus.livewire]
+schematic_scale = 0.1
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,11 @@ skip = "*.lock,*.svg,*.gds,*.oas,*.lib,ihp/models/ngspice/va/*"
 [tool.gdsfactoryplus]
 name = "ihp"
 
-[tool.gdsfactoryplus.pdk]
-name = "ihp"
-
 [tool.gdsfactoryplus.livewire]
 schematic_scale = 0.1
+
+[tool.gdsfactoryplus.pdk]
+name = "ihp"
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary

Sets `schematic_scale = 0.1` in both IHP pyproject files so that Mosaic schematic grid units map to 0.1 µm in Livewire's world coordinate space.

- `pyproject.toml` (repo root)
- `ihp-gdsfactory--sample-projects/ihp--public--project/pyproject.toml`

Requires GDSFactory+ with `livewire.settings` RPC support (doplaydo/gdsfactoryplus#3268).