### PR TITLE
feat(docs): add 3D view as third tab in cells page

### DIFF
--- a/.github/write_cells.py
+++ b/.github/write_cells.py
@@ -122,7 +122,10 @@ def write_cell_entry(f, name, cell_dict, module_path="ihp.cells", import_alias="
 """
         )
 
-        # Write GDS and save PNG for Static/Dynamic tabs
+        # Generate 3D GLB before writing tabs
+        glb_file = make_3d_glb(name, cell_dict)
+
+        # Write GDS and save PNG for Static/Dynamic/3D tabs
         try:
             c = cell_dict[name]()
             c.write_gds(gds_dir / f"{name}.gds")
@@ -138,18 +141,16 @@ def write_cell_entry(f, name, cell_dict, module_path="ihp.cells", import_alias="
                 f' loading="lazy" width="100%" height="400"'
                 f' style="border:none"></iframe>\n\n'
             )
+            if glb_file:
+                f.write('=== "3D"\n\n')
+                f.write(
+                    f'    <iframe class="viewer-3d"'
+                    f' src="_static/3d/viewer.html?file={glb_file}"'
+                    f' width="100%" height="500px" frameborder="0"'
+                    f' loading="lazy"></iframe>\n\n'
+                )
         except Exception as e:
             print(f"  [kwasm skip] {name}: {e}")
-
-        # Generate 3D GLB and embed via shared viewer
-        glb_file = make_3d_glb(name, cell_dict)
-        if glb_file:
-            f.write(
-                f"""
-<iframe class="viewer-3d" src="_static/3d/viewer.html?file={glb_file}" width="100%" height="500px" frameborder="0" loading="lazy"></iframe>
-
-"""
-            )
 
         f.write(
             f"""```python


### PR DESCRIPTION
## Summary

- Move the 3D GLB viewer from a standalone iframe into the tab group as a "3D" tab alongside "Static" and "Dynamic"
- Generate the GLB before writing tabs so the 3D tab can be included in the same tab group
- 3D tab only appears when GLB export succeeds for a given cell

Closes #205

## Test plan

- [ ] Run `write_cells.py` and verify the generated `cells.md` has `=== "3D"` tabs
- [ ] Build docs and confirm the 3D tab renders correctly alongside Static and Dynamic
- [ ] Verify cells where GLB export fails still show only Static and Dynamic tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a conditional 3D tab to the cells documentation by generating GLB assets ahead of tab rendering and embedding the shared 3D viewer within the existing tab group.

New Features:
- Add a 3D documentation tab for cells alongside the existing Static and Dynamic tabs when GLB export succeeds.

Enhancements:
- Integrate the 3D GLB viewer into the existing tab group instead of using a standalone iframe section.
- Generate GLB assets before writing documentation tabs so 3D content can be conditionally included in the tab group.