### PR TITLE
feat(docs): add palace simulation notebooks to zensical docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ docs/cells_fixed.md
 docs/cells2_reference.md
 docs/changelog.md
 docs/index.md
+docs/palace_demo_cpw.md
+docs/palace_demo_microstrip.md
 *.glb
 
 # Simulation outputs

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,14 @@ cp-docs:
 	cp CHANGELOG.md docs/changelog.md
 
 notebooks:
-	uv run --extra docs jupyter nbconvert --to markdown docs/palace_demo_cpw.ipynb docs/palace_demo_microstrip.ipynb
+	uv run --extra docs --extra simulation jupyter nbconvert --to notebook --execute \
+		--ExecutePreprocessor.timeout=600 \
+		--output-dir /tmp/ihp-notebooks \
+		docs/palace_demo_cpw.ipynb docs/palace_demo_microstrip.ipynb
+	uv run --extra docs jupyter nbconvert --to markdown \
+		--output-dir docs \
+		/tmp/ihp-notebooks/palace_demo_cpw.ipynb \
+		/tmp/ihp-notebooks/palace_demo_microstrip.ipynb
 	uv run python docs/hooks.py docs/palace_demo_cpw.md docs/palace_demo_microstrip.md
 
 docs: cp-docs cells notebooks

--- a/Makefile
+++ b/Makefile
@@ -62,8 +62,8 @@ cp-docs:
 	cp CHANGELOG.md docs/changelog.md
 
 notebooks:
-	@if [ "$$(uname -s)" = "Linux" ]; then sudo apt-get install -y --no-install-recommends libglu1-mesa libgl1 2>/dev/null; fi
-	uv run --extra docs --extra simulation jupyter nbconvert --to notebook --execute \
+	@if [ "$$(uname -s)" = "Linux" ]; then sudo apt-get install -y --no-install-recommends libglu1-mesa libgl1 libegl1 libosmesa6 2>/dev/null; fi
+	VTK_DEFAULT_RENDER_WINDOW_OFFSCREEN=1 uv run --extra docs --extra simulation jupyter nbconvert --to notebook --execute \
 		--ExecutePreprocessor.timeout=600 \
 		--output-dir /tmp/ihp-notebooks \
 		docs/palace_demo_cpw.ipynb docs/palace_demo_microstrip.ipynb

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ gmsh:
 	sudo apt-get install -y python3-gmsh gmsh libglu1-mesa libxi-dev libxmu-dev libglu1-mesa-dev libosmesa6 libegl1
 
 docs-clean:
-	rm -rf docs/_build
+	rm -rf docs/_build docs/palace_demo_cpw.md docs/palace_demo_microstrip.md
 
 mask:
 	python ubcpdk/samples/test_masks.py
@@ -61,13 +61,17 @@ cp-docs:
 	cp README.md docs/index.md
 	cp CHANGELOG.md docs/changelog.md
 
-docs: cp-docs cells
+notebooks:
+	uv run --extra docs jupyter nbconvert --to markdown docs/palace_demo_cpw.ipynb docs/palace_demo_microstrip.ipynb
+	uv run python docs/hooks.py docs/palace_demo_cpw.md docs/palace_demo_microstrip.md
+
+docs: cp-docs cells notebooks
 	uv run --extra docs zensical build -f docs/zensical.toml
 
-docs-serve: cp-docs
+docs-serve: cp-docs notebooks
 	uv run --extra docs zensical serve -f docs/zensical.toml -a localhost:8080
 
 update-changelog:
 	claude -p "remove links and make a user friendly changelog from @CHANGELOG.md to @docs/changelog.md"
 
-.PHONY: drc drc-sample doc docs docs-pdf build update-changelog
+.PHONY: drc drc-sample doc docs docs-pdf build update-changelog notebooks

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ cp-docs:
 	cp CHANGELOG.md docs/changelog.md
 
 notebooks:
+	@if [ "$$(uname -s)" = "Linux" ]; then sudo apt-get install -y --no-install-recommends libglu1-mesa libgl1 2>/dev/null; fi
 	uv run --extra docs --extra simulation jupyter nbconvert --to notebook --execute \
 		--ExecutePreprocessor.timeout=600 \
 		--output-dir /tmp/ihp-notebooks \

--- a/docs/palace_demo_cpw.ipynb
+++ b/docs/palace_demo_cpw.ipynb
@@ -187,7 +187,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.plot_interactive()"
+    "# Show simulation output files\n",
+    "print(\"Output files:\")\n",
+    "for name, path in results.items():\n",
+    "    print(f\"  {name}: {path}\")"
    ]
   },
   {
@@ -197,7 +200,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.plot_interactive(phase=True)"
+    "# Read and display S-parameters\n",
+    "import pandas as pd\n",
+    "s_df = pd.read_csv(results[\"port-S.csv\"])\n",
+    "s_df"
    ]
   }
  ],

--- a/docs/palace_demo_microstrip.ipynb
+++ b/docs/palace_demo_microstrip.ipynb
@@ -140,7 +140,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.plot_interactive()"
+    "# Show simulation output files\n",
+    "print(\"Output files:\")\n",
+    "for name, path in results.items():\n",
+    "    print(f\"  {name}: {path}\")"
    ]
   },
   {
@@ -150,7 +153,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results.plot_interactive(phase=True)"
+    "# Read and display S-parameters\n",
+    "import pandas as pd\n",
+    "s_df = pd.read_csv(results[\"port-S.csv\"])\n",
+    "s_df"
    ]
   }
  ],

--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -7,6 +7,10 @@ nav = [
   {"Reference" = [
     {"Cells" = "cells.md"},
     {"Changelog" = "changelog.md"}
+  ]},
+  {"Simulation" = [
+    {"Palace CPW Demo" = "palace_demo_cpw.md"},
+    {"Palace Microstrip Demo" = "palace_demo_microstrip.md"}
   ]}
 ]
 repo_name = "gdsfactory/IHP"


### PR DESCRIPTION
## Summary

- Adds a `notebooks` Makefile target that converts `palace_demo_cpw.ipynb` and `palace_demo_microstrip.ipynb` to markdown via `nbconvert`, then post-processes with `docs/hooks.py` (MyST admonition conversion, curly brace escaping)
- Wires `notebooks` into the `docs` and `docs-serve` targets
- Adds a **Simulation** section to the `zensical.toml` nav with both palace demo pages
- Marks generated `.md` files as build artifacts in `.gitignore` and `docs-clean`

The notebooks existed in `docs/` but were never included in the built site — zensical has no native notebook support, so pre-conversion via `nbconvert` is required.

## Test plan

- [ ] `make notebooks` — converts both `.ipynb` → `.md` without errors
- [ ] `make docs` — build succeeds with `No issues found`
- [ ] `docs/_build/html/palace_demo_cpw/index.html` and `palace_demo_microstrip/index.html` exist in output
- [ ] `make docs-clean` removes generated `.md` files

## Summary by Sourcery

Add generated Palace simulation notebook pages to the documentation build and navigation.

Build:
- Introduce a Makefile notebooks target to convert Palace demo Jupyter notebooks to markdown and post-process them for docs.
- Wire the notebooks target into docs and docs-serve so simulation pages are built and served with the main documentation.
- Extend docs-clean to remove generated Palace demo markdown files as build artifacts.

Documentation:
- Add a Simulation section to the docs navigation containing Palace CPW and microstrip demo pages.

Chores:
- Ignore generated Palace demo markdown files in version control via .gitignore.