### PR TITLE
docs: clarify README directory descriptions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @thanojo @cdaunt @das-dias
+* @joamatab @thanojo @cdaunt @das-dias @ThomasPluck

--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ ihp/
 │   ├── via_stacks.py       #   Via stack generators
 │   └── bondpads.py         #   Bondpad cells
 ├── models/                 # Compact models & SAX S-parameter models
-├── gds/                    # Pre-built GDS files for complex cells
+├── gds/                    # Pre-built GDS files for some cells
 ├── tech.py                 # Layer map, design rules, technology parameters
-├── layers.yaml             # Layer definitions
+├── layers.yaml             # Layer properties and colors for KLayout LYP
 └── config.py               # Paths and PDK configuration
 tests/
 ├── test_cells.py           # GDS regression & settings tests for all cells
 └── gds_ref/                # Golden reference GDS files
-docs/                       # Jupyter Book documentation (Sphinx)
+docs/                       # Documentation
 ```
 
 **Key architectural concepts:**


### PR DESCRIPTION
## Summary
- Clarify `gds/` description: pre-built GDS files for "some cells" (not "complex cells")
- Clarify `layers.yaml` description: layer properties and colors for KLayout LYP
- Simplify `docs/` description: just "Documentation"

## Test plan
- [ ] Verify README renders correctly on GitHub

## Summary by Sourcery

Clarify directory descriptions in the README for GDS files, layer configuration, and documentation.

Documentation:
- Update README to refine descriptions of the gds/ directory contents and layers.yaml purpose.
- Simplify README description of the docs/ directory to a generic documentation label.