### PR TITLE
chore(deps): bump gdsfactory to ~=9.45.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
-  "gdsfactory~=9.44.0",
+  "gdsfactory~=9.45.0",
   "gplugins[sax]~=2.1.0",
   "scikit-rf>=1.0.0",
   "gdsfactoryplus"


### PR DESCRIPTION
## Summary
- Bump `gdsfactory` dependency from `~=9.44.0` to `~=9.45.0`

## Test plan
- [ ] CI passes with the new dependency version
- [ ] Existing tests and notebooks remain functional