### PR TITLE
update freq

### DIFF
--- a/ihp-gdsfactory--sample-projects/ihp--public--project/pyproject.toml
+++ b/ihp-gdsfactory--sample-projects/ihp--public--project/pyproject.toml
@@ -11,9 +11,10 @@ classifiers = [
   "Programming Language :: Python :: 3.12"
 ]
 dependencies = [
-  "gdsfactory~=9.44.0",
-  "gdsfactoryplus",
-  "gplugins[sax]~=1.4.2"
+  "gdsfactory~=9.45.0",
+  "gplugins[sax]~=2.1.0",
+  "scikit-rf>=1.0.0",
+  "gdsfactoryplus"
 ]
 description = "IHP pdk"
 keywords = ["python"]
@@ -22,18 +23,27 @@ name = "ihp"
 readme = "README.md"
 requires-python = "~=3.12.0"
 version = "0.0.6"
-optional-dependencies.dev = [
-  "pre-commit",
+
+[project.optional-dependencies]
+dev = [
   "pytest",
   "pytest-cov",
-  "jsondiff",
+  "pytest_regressions",
+  'jsondiff',
   "pytest-github-actions-annotate-failures",
-  "pytest-regressions"
+  "pre-commit"
 ]
-optional-dependencies.docs = [
-  "autodoc-pydantic",
-  "jupyter-book==1.0.3",
-  "jupytext"
+docs = [
+  "jupyter",
+  "kwasm",
+  "mkdocs-material",
+  "mkdocs-with-pdf",
+  "nbconvert",
+  "mkdocstrings[python]>=0.27.0",
+  "zensical>=0.0.40,<0.1.0"
+]
+simulation = [
+  "gsim>=0.0.16; python_version>='3.12'"
 ]
 
 [tool.basedpyright]

--- a/ihp/samples/all_cells.py
+++ b/ihp/samples/all_cells.py
@@ -4,9 +4,8 @@ import gdsfactory as gf
 
 from ihp import LAYER, PDK
 
-skip = {
-    "all_cells",
-}
+skip = {"all_cells", "extend_ports"}
+skip.update(gf.gpdk.PDK.cells.keys())
 
 
 @gf.cell
@@ -29,7 +28,7 @@ def all_cells() -> gf.Component:
         size=(cell_matrix.xsize + 20, cell_matrix.ysize + 20),
         layer=LAYER.Recogdrawing,
     )
-    floorplan.dcenter = cell_matrix.dcenter
+    floorplan.center = cell_matrix.center
     return c
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ schematic_scale = 0.1
 [tool.gdsfactoryplus.pdk]
 name = "ihp"
 
+[tool.gdsfactoryplus.sim.x]
+max = 15  # 15GHz
+min = 1  # 1GHz
+name = "f"
+num = 4001
+
 [tool.mypy]
 python_version = "3.12"
 strict = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
-  "gdsfactory~=9.44.0",
+  "gdsfactory~=9.45.0",
   "gplugins[sax]~=2.1.0",
   "scikit-rf>=1.0.0",
   "gdsfactoryplus"

--- a/uv.lock
+++ b/uv.lock
@@ -784,7 +784,7 @@ wheels = [
 
 [[package]]
 name = "gdsfactory"
-version = "9.44.0"
+version = "9.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -820,9 +820,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchdog" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/77/6b1751eab32f1ec7c4506a2dadb59194878f729de84905756b1c3a438343/gdsfactory-9.44.0.tar.gz", hash = "sha256:f993d35df133110938a368a6a3de60c23672ec7e5877a37c17eb92c630077727", size = 555361, upload-time = "2026-06-12T15:33:26.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/2c/46796cd9e022fc2f5a54b82bcfd7c5a45f5edfe6889461e5320d9ce2837e/gdsfactory-9.45.0.tar.gz", hash = "sha256:618781460dbaa4e50a2039b14a3ba88ef53f6b46bd90c98f12f3aa4f5bd45896", size = 558352, upload-time = "2026-07-03T13:32:15.991Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/c9/eb4b7a5c8b4c05cb9d2dbf348527f58029dd23f118bdf1919ee2f6dde5a5/gdsfactory-9.44.0-py3-none-any.whl", hash = "sha256:e07473acb91af16dd55c2964d13974e86ee7614dad70f70503543d9223c899d0", size = 806596, upload-time = "2026-06-12T15:33:23.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/a6/c7a7cb059f57df14f13dbad7dcd069a5eafdcfa970288d4b4cafb6c6871e/gdsfactory-9.45.0-py3-none-any.whl", hash = "sha256:98a3c13b23b8740083e71c3ea8fbf75fe6f729416943efa5eb76b18ebd7d5100", size = 809978, upload-time = "2026-07-03T13:32:14.245Z" },
 ]
 
 [[package]]
@@ -1067,7 +1067,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "gdsfactory", specifier = "~=9.44.0" },
+    { name = "gdsfactory", specifier = "~=9.45.0" },
     { name = "gdsfactoryplus" },
     { name = "gplugins", extras = ["sax"], specifier = "~=2.1.0" },
     { name = "gsim", marker = "python_full_version >= '3.12' and extra == 'simulation'", specifier = ">=0.0.16" },
@@ -1574,7 +1574,7 @@ wheels = [
 
 [[package]]
 name = "kfactory"
-version = "2.5.2"
+version = "2.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aenum" },
@@ -1595,9 +1595,9 @@ dependencies = [
     { name = "toolz" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/7b/47661b663d9c2e3fe050f3d86a8a95e3902e506bbfadb9e7c9acd830186d/kfactory-2.5.2.tar.gz", hash = "sha256:9c76c930497db92f9eec68830e341a3ae30f4a9c8353b806fbc98abf605d1577", size = 13525752, upload-time = "2026-05-13T13:45:59.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/de/b1/db2bbdffe2c28032661fe306eb2dae1b54c0f85592d4b86b326453044653/kfactory-2.6.1.tar.gz", hash = "sha256:e469e52efa3d853df89b4ec15d0324b2a389555e0ec8fce5bd347d32e2c0ca97", size = 13551991, upload-time = "2026-07-01T22:44:46.038Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/0b/bd39b63d1690aa9c78baea3e42786d48e1aedb1ac6493a9c4aa361e05f3e/kfactory-2.5.2-py3-none-any.whl", hash = "sha256:9f3e628373399fd1f25588a1108b9d7db1e3a786d363039e24d3c36aaa41168b", size = 253234, upload-time = "2026-05-13T13:46:02.71Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/29/dae62742e7b675c01b1d6e2dd8ee88cdb59a5d1ccf482818bda1d471333f/kfactory-2.6.1-py3-none-any.whl", hash = "sha256:34324989d4a5fa99aee636b7378ad42404d685cb754b40ad9f90280c321a02ea", size = 255125, upload-time = "2026-07-01T22:44:43.472Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
- **chore(deps): bump gdsfactory to ~=9.45.0**
- **update freqs**

## Summary by Sourcery

Bump the gdsfactory dependency and configure simulation frequency sweep parameters for the PDK.

New Features:
- Define gdsfactoryplus simulation frequency sweep settings, including frequency range and resolution.

Enhancements:
- Update gdsfactory dependency to version 9.45.x.