### PR TITLE
fix(docs): escape LaTeX sqrt in wilkinson_power_divider docstring

### DIFF
--- a/ihp/cells/rf_devices.py
+++ b/ihp/cells/rf_devices.py
@@ -244,7 +244,7 @@ def wilkinson_power_divider(
     shape: str = "C",
     e_r: float = 4.1,
 ) -> gf.Component:
-    """Return a Wilkinson power divider coplanar transmission line.
+    r"""Return a Wilkinson power divider coplanar transmission line.
 
     Constructs a two-way Wilkinson divider from quarter-wave transformer
     branches (impedance $Z_0 / \sqrt{2}$) arranged in a loop.  The

--- a/ihp/cells/rf_devices.py
+++ b/ihp/cells/rf_devices.py
@@ -247,7 +247,7 @@ def wilkinson_power_divider(
     """Return a Wilkinson power divider coplanar transmission line.
 
     Constructs a two-way Wilkinson divider from quarter-wave transformer
-    branches (impedance $Z_0 / sqrt{2}$) arranged in a loop.  The
+    branches (impedance $Z_0 / \sqrt{2}$) arranged in a loop.  The
     quarter-wave length is derived from *frequency* and the effective
     dielectric constant of the selected cross-section stack.
 


### PR DESCRIPTION
## Summary
- Add missing backslash before `sqrt` in the `wilkinson_power_divider` docstring LaTeX formula
- Changes `$Z_0 / sqrt{2}$` to `$Z_0 / \sqrt{2}$` so it renders correctly in the docs

Fixes https://gdsfactory.github.io/IHP/cells/#__tabbed_14_1

## Test plan
- [ ] Verify the formula renders correctly on the docs site after deployment

## Summary by Sourcery

Documentation:
- Fix the LaTeX formula in the wilkinson_power_divider docstring by properly escaping the sqrt function.