### PR TITLE
feat(ihp): add geometric and logical pins to all electrical PCells

### DIFF
--- a/ihp/_common.py
+++ b/ihp/_common.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import gdsfactory as gf
+from gdsfactory.add_pins import add_pin_rectangle_inside
+
+
+def _add_pins(c: gf.Component) -> None:
+    """Draw pin rectangles and register logical pins for all electrical ports."""
+    by_name: dict[str, list] = {}
+    for port in c.ports:
+        if port.port_type == "electrical":
+            by_name.setdefault(port.name, []).append(port)
+    for name, ports in by_name.items():
+        for port in ports:
+            add_pin_rectangle_inside(c, port, layer=port.layer, layer_label=None)
+        c.create_pin(ports=ports, name=name)

--- a/ihp/cells/bjt_transistors.py
+++ b/ihp/cells/bjt_transistors.py
@@ -7,6 +7,7 @@ from gdsfactory.typings import LayerSpec
 from kfactory.schematic import DSchematic
 
 from ihp.tech import TECH as _TECH
+from ihp._common import _add_pins
 
 _XS = "metal1_routing"
 
@@ -785,6 +786,7 @@ def npn13G2(
         port_type="electrical",
     )
 
+    _add_pins(c)
     return c
 
 
@@ -1391,6 +1393,7 @@ def npn13G2L(
         ),
     )
 
+    _add_pins(c)
     return c
 
 
@@ -2018,6 +2021,7 @@ def npn13G2V(
         ),
     )
 
+    _add_pins(c)
     return c
 
 
@@ -2600,4 +2604,5 @@ def pnpMPA(length: float = 2, width: float = 0.7) -> gf.Component:
         port_type="electrical",
     )
 
+    _add_pins(c)
     return c

--- a/ihp/cells/bondpads.py
+++ b/ihp/cells/bondpads.py
@@ -9,7 +9,7 @@ from gdsfactory.typings import LayerSpec
 from kfactory.schematic import DSchematic
 
 from ..config import PATH
-
+from .._common import _add_pins
 _XS = "metal1_routing"
 
 
@@ -149,6 +149,7 @@ def bondpad(
     c.info["diameter"] = diameter
     c.info["top_metal"] = layer_top_metal
 
+    _add_pins(c)
     return c
 
 
@@ -210,6 +211,7 @@ def bondpad_array(
 
     # TODO: Bondpad array VLSIR Metadata
 
+    _add_pins(c)
     return c
 
 

--- a/ihp/cells/capacitors.py
+++ b/ihp/cells/capacitors.py
@@ -10,6 +10,7 @@ from ihp import tech
 from ihp.cells.passives import guard_ring
 from ihp.cells.via_stacks import via_array, via_stack
 from ihp.tech import CbCapCalc
+from .._common import _add_pins
 
 _XS = "metal1_routing"
 
@@ -311,6 +312,7 @@ def cmom(
     c.info["spacing"] = spacing
 
     #   return the component
+    _add_pins(c)
     return c
 
 
@@ -565,6 +567,7 @@ def cmim(
     c.info["capacitance_fF"] = capacitance
     c.info["area_um2"] = width * length
 
+    _add_pins(c)
     return c
 
 
@@ -786,4 +789,5 @@ def rfcmim(
     c.add_label(text="TIE_LOW", position=(tie.x, tie.y), layer=layer_metal1label)
     c.add_label(text="TIE_LOW", position=(tie.x, tie.y), layer=layer_text)
 
+    _add_pins(c)
     return c

--- a/ihp/cells/fet_transistors.py
+++ b/ihp/cells/fet_transistors.py
@@ -17,6 +17,7 @@ from gdsfactory.typings import LayerSpec
 from kfactory.schematic import DSchematic
 
 from ..tech import TECH
+from .._common import _add_pins
 
 _XS = "metal1_routing"
 
@@ -596,6 +597,7 @@ def nmos(
         )
 
     c = _mos_core(width, length, nf, is_pmos=False, is_hv=False)
+    _add_pins(c)
     return c
 
 
@@ -677,6 +679,7 @@ def pmos(
         raise ValueError(f"pmos nf={nf} out of range [1, {TECH.pmos_max_nf}]")
 
     c = _mos_core(width, length, nf, is_pmos=True, is_hv=False)
+    _add_pins(c)
     return c
 
 
@@ -758,6 +761,7 @@ def nmos_hv(
         raise ValueError(f"nmos_hv nf={nf} out of range [1, {TECH.nmos_hv_max_nf}]")
 
     c = _mos_core(width, length, nf, is_pmos=False, is_hv=True)
+    _add_pins(c)
     return c
 
 
@@ -839,4 +843,5 @@ def pmos_hv(
         raise ValueError(f"pmos_hv nf={nf} out of range [1, {TECH.pmos_hv_max_nf}]")
 
     c = _mos_core(width, length, nf, is_pmos=True, is_hv=True)
+    _add_pins(c)
     return c

--- a/ihp/cells/inductors.py
+++ b/ihp/cells/inductors.py
@@ -6,6 +6,8 @@ import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.typings import LayerSpec, LayerSpecs
 
+from .._common import _add_pins
+
 
 def snap_to_grid(p, grid: float = 0.005):
     return round(p / grid) * grid
@@ -302,6 +304,7 @@ def inductor2(
     c.info["space"] = space
     c.info["diameter"] = diameter
 
+    _add_pins(c)
     return c
 
 

--- a/ihp/cells/passives.py
+++ b/ihp/cells/passives.py
@@ -10,6 +10,7 @@ from kfactory.schematic import DSchematic
 from numpy import floor, round
 
 from ihp import cells, tech
+from ihp._common import _add_pins
 
 _XS = "metal1_routing"
 
@@ -220,6 +221,7 @@ def svaricap(
         port_type="electrical",
     )
 
+    _add_pins(c)
     return c
 
 
@@ -430,6 +432,7 @@ def esd_nmos(
         port_type="electrical",
     )
 
+    _add_pins(c)
     return c
 
 
@@ -582,6 +585,7 @@ def ptap1(
     c.info["rows"] = rows
     c.info["cols"] = cols
 
+    _add_pins(c)
     return c
 
 
@@ -745,6 +749,7 @@ def ntap1(
     c.info["rows"] = rows
     c.info["cols"] = cols
 
+    _add_pins(c)
     return c
 
 
@@ -928,6 +933,7 @@ def sealring(
     c.info["height"] = height
     c.info["ring_width"] = ring_width
 
+    _add_pins(c)
     return c
 
 
@@ -1118,4 +1124,5 @@ def guard_ring(
     c.info["rows"] = nrows
     c.info["guardRingSpacing"] = guardRingSpacing
 
+    _add_pins(c)
     return c

--- a/ihp/cells/resistors.py
+++ b/ihp/cells/resistors.py
@@ -7,6 +7,8 @@ from kfactory.schematic import DSchematic
 
 from ihp.tech import TECH as _TECH
 
+from .._common import _add_pins
+
 _XS = "metal1_routing"
 
 
@@ -240,6 +242,7 @@ def rsil(
         }
     )
 
+    _add_pins(c)
     return c
 
 
@@ -473,6 +476,7 @@ def rppd(
         }
     )
 
+    _add_pins(c)
     return c
 
 
@@ -707,4 +711,5 @@ def rhigh(
         }
     )
 
+    _add_pins(c)
     return c

--- a/ihp/cells/rf_transistors.py
+++ b/ihp/cells/rf_transistors.py
@@ -14,6 +14,7 @@ from gdsfactory.typings import LayerSpec
 from kfactory.schematic import DSchematic
 
 from ..tech import TECH
+from .._common import _add_pins
 from .fet_transistors import _add_rect, _even_dbu, _fix, _grid_fix
 
 _XS = "metal1_routing"
@@ -999,6 +1000,7 @@ def rfnmos(
         is_pmos=False,
         is_hv=False,
     )
+    _add_pins(c)
     return c
 
 
@@ -1114,6 +1116,7 @@ def rfpmos(
         is_pmos=True,
         is_hv=False,
     )
+    _add_pins(c)
     return c
 
 
@@ -1229,6 +1232,7 @@ def rfnmos_hv(
         is_pmos=False,
         is_hv=True,
     )
+    _add_pins(c)
     return c
 
 
@@ -1344,4 +1348,5 @@ def rfpmos_hv(
         is_pmos=True,
         is_hv=True,
     )
+    _add_pins(c)
     return c

--- a/ihp/cells/via_stacks.py
+++ b/ihp/cells/via_stacks.py
@@ -4,6 +4,9 @@ import gdsfactory as gf
 from gdsfactory import Component
 from gdsfactory.typings import LayerSpec
 
+from .._common import _add_pins
+
+
 # Via design rules (in micrometers)
 VIA_RULES = {
     "Cont": {
@@ -164,6 +167,7 @@ def via_array(
     c.info["enclosure_width"] = array_width + 2 * enclosure
     c.info["enclosure_height"] = array_height + 2 * enclosure
 
+    _add_pins(c)
     return c
 
 
@@ -396,6 +400,7 @@ def via_stack(
     c.info["height"] = height
     c.info["n_layers"] = len(layer_order)
 
+    _add_pins(c)
     return c
 
 
@@ -556,4 +561,5 @@ def via_stack_with_pads(
         port_type="electrical",
     )
 
+    _add_pins(c)
     return c

--- a/ihp/refs/antennas.py
+++ b/ihp/refs/antennas.py
@@ -7,6 +7,7 @@ import gdsfactory as gf
 from .. import tech
 from .ihp_pycell import dantenna as dantennaIHP
 from .ihp_pycell import dpantenna as dpantennaIHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -77,6 +78,7 @@ def dantenna(
         ports_on_short_side=True,
     )
 
+    _add_pins(c)
     return c
 
 
@@ -149,4 +151,5 @@ def dpantenna(
         ports_on_short_side=True,
     )
 
+    _add_pins(c)
     return c

--- a/ihp/refs/bjt_transistors.py
+++ b/ihp/refs/bjt_transistors.py
@@ -5,6 +5,7 @@ from .ihp_pycell import npn13G2 as npn13G2IHP
 from .ihp_pycell import npn13G2L as npn13G2LIHP
 from .ihp_pycell import npn13G2V as npn13G2VIHP
 from .ihp_pycell import pnpMPA as pnpMPAIHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -101,6 +102,7 @@ def npn13G2(
     # c.ports["e2"].name = "C"
     # c.ports["e3"].name = "E"
 
+    _add_pins(c)
     return c
 
 
@@ -165,6 +167,7 @@ def npn13G2L(
     c.ports["e2"].name = "E"
     c.ports["e3"].name = "C"
 
+    _add_pins(c)
     return c
 
 
@@ -229,6 +232,7 @@ def npn13G2V(
     c.ports["e2"].name = "C"
     c.ports["e3"].name = "E"
 
+    _add_pins(c)
     return c
 
 
@@ -283,4 +287,5 @@ def pnpMPA(
     c.ports["e2"].name = "PLUS"
     c.ports["e3"].name = "MINUS"
 
+    _add_pins(c)
     return c

--- a/ihp/refs/capacitors.py
+++ b/ihp/refs/capacitors.py
@@ -9,6 +9,7 @@ from .ihp_pycell import CbCapCalc, eng_string
 from .ihp_pycell import SVaricap as SVaricapIHP
 from .ihp_pycell import cmim as cmimIHP
 from .ihp_pycell import rfcmim as rfcmimIHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -83,6 +84,7 @@ def cmim(
     c.ports["B"].orientation = 0
     c.ports["T"].orientation = 180
 
+    _add_pins(c)
     return c
 
 
@@ -156,6 +158,7 @@ def rfcmim(
     )
     c.ports["e1"].name = "TIE"
 
+    _add_pins(c)
     return c
 
 
@@ -213,6 +216,7 @@ def svaricap(
     c.ports["e2"].orientation = 270
     c.ports["e3"].orientation = 180
 
+    _add_pins(c)
     return c
 
 

--- a/ihp/refs/inductors.py
+++ b/ihp/refs/inductors.py
@@ -5,6 +5,7 @@ import gdsfactory as gf
 from .. import tech
 from .ihp_pycell import inductor2 as inductor2IHP
 from .ihp_pycell import inductor3 as inductor3IHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -85,6 +86,7 @@ def inductor2(
     c.ports["e1"].name = "LB"
     c.ports["e2"].name = "LA"
 
+    _add_pins(c)
     return c
 
 
@@ -175,4 +177,5 @@ def inductor3(
     for port in c.ports:
         port.orientation = 270  # all ports should face downwards
 
+    _add_pins(c)
     return c

--- a/ihp/refs/mos_transistors.py
+++ b/ihp/refs/mos_transistors.py
@@ -16,6 +16,7 @@ from .ihp_pycell import rfnmos as rfnmosIHP
 from .ihp_pycell import rfnmosHV as rfnmosHVIHP
 from .ihp_pycell import rfpmos as rfpmosIHP
 from .ihp_pycell import rfpmosHV as rfpmosHVIHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -125,6 +126,7 @@ def nmos(
         port_name_prefix="G_",
         ports_on_short_side=True,
     )
+    _add_pins(c)
     return c
 
 
@@ -198,6 +200,7 @@ def nmosHV(
         ports_on_short_side=True,
     )
 
+    _add_pins(c)
     return c
 
 
@@ -269,6 +272,7 @@ def pmos(
         port_name_prefix="G_",
         ports_on_short_side=True,
     )
+    _add_pins(c)
     return c
 
 
@@ -341,6 +345,7 @@ def pmosHV(
         port_name_prefix="G_",
         ports_on_short_side=True,
     )
+    _add_pins(c)
     return c
 
 
@@ -424,6 +429,7 @@ def rfnmos(
         port_name_prefix="G_",
         ports_on_short_side=True,
     )
+    _add_pins(c)
     return c
 
 
@@ -488,6 +494,7 @@ def rfnmosHV(
     # Adjust port orientations, for metal1 so every other port points in the opposite direction
     # for i, port in enumerate(c.ports):
     #     port.orientation = 90 if port.name.startswith("DS_") and i % 2 == 1 else port.orientation
+    _add_pins(c)
     return c
 
 
@@ -552,6 +559,7 @@ def rfpmos(
     # Adjust port orientations, for metal1 so every other port points in the opposite direction
     # for i, port in enumerate(c.ports):
     #     port.orientation = 90 if port.name.startswith("DS_") and i % 2 == 1 else port.orientation
+    _add_pins(c)
     return c
 
 
@@ -616,4 +624,5 @@ def rfpmosHV(
     # Adjust port orientations, for metal1 so every other port points in the opposite direction
     # for i, port in enumerate(c.ports):
     #     port.orientation = 90 if port.name.startswith("DS_") and i % 2 == 1 else port.orientation
+    _add_pins(c)
     return c

--- a/ihp/refs/passives.py
+++ b/ihp/refs/passives.py
@@ -10,6 +10,7 @@ from .ihp_pycell import esd as esdIHP
 from .ihp_pycell import ntap1 as ntap1IHP
 from .ihp_pycell import ptap1 as ptap1IHP
 from .ihp_pycell import sealring as sealringIHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -132,6 +133,7 @@ def esd(
         c.ports["e2"].orientation = 90
         c.ports["e2"].name = "VDD"
 
+    _add_pins(c)
     return c
 
 
@@ -185,6 +187,7 @@ def ptap1(
         ports_on_short_side=True,
     )
 
+    _add_pins(c)
     return c
 
 
@@ -235,6 +238,7 @@ def ntap1(
         ports_on_short_side=True,
     )
 
+    _add_pins(c)
     return c
 
 
@@ -282,6 +286,7 @@ def sealring(
     # add ports to the component
     # ports should be added manually if needed
 
+    _add_pins(c)
     return c
 
 

--- a/ihp/refs/resistors.py
+++ b/ihp/refs/resistors.py
@@ -9,6 +9,7 @@ from .ihp_pycell import CbResCalc, CbResCurrent, eng_string_to_float
 from .ihp_pycell import rhigh as rhighIHP
 from .ihp_pycell import rppd as rppdIHP
 from .ihp_pycell import rsil as rsilIHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -98,6 +99,7 @@ def rhigh(
         ports_on_short_side=False,
     )
 
+    _add_pins(c)
     return c
 
 
@@ -187,6 +189,7 @@ def rppd(
         ports_on_short_side=False,
     )
 
+    _add_pins(c)
     return c
 
 
@@ -273,6 +276,7 @@ def rsil(
         ports_on_short_side=False,
     )
 
+    _add_pins(c)
     return c
 
 

--- a/ihp/refs/via_stacks.py
+++ b/ihp/refs/via_stacks.py
@@ -7,6 +7,7 @@ import gdsfactory as gf
 from .. import tech
 from .ihp_pycell import NoFillerStack as no_filler_stackIHP
 from .ihp_pycell import via_stack as via_stackIHP
+from .._common import _add_pins
 from .utils import *
 
 
@@ -108,6 +109,7 @@ def via_stack(
     )
     c.ports["e1"].name = "top"
 
+    _add_pins(c)
     return c
 
 
@@ -173,6 +175,7 @@ def no_filler_stack(
     # Adjust port orientations, for metal1 so every other port points in the opposite direction
     # for i, port in enumerate(c.ports):
     #     port.orientation = 90 if port.name.startswith("DS_") and i % 2 == 1 else port.orientation
+    _add_pins(c)
     return c
 
 

--- a/tests/test_electrical_pins.py
+++ b/tests/test_electrical_pins.py
@@ -1,0 +1,98 @@
+"""Tests verifying geometric and logical electrical pins on IHP PCells."""
+
+from __future__ import annotations
+
+import pytest
+import kfactory as kf
+
+from ihp import PDK
+
+kdb = kf.kdb
+
+
+@pytest.fixture(autouse=True)
+def activate_pdk():
+    PDK.activate()
+
+
+# Electrical PCells from cells/ and cells2/ that have electrical ports
+CELL_NAMES = [
+    # resistors (cells/)
+    "rsil",
+    "rppd",
+    "rhigh",
+    # FET transistors (cells/)
+    "nmos",
+    "pmos",
+    "nmos_hv",
+    "pmos_hv",
+    # RF transistors (cells/)
+    "rfnmos",
+    "rfnmos_hv",
+    "rfpmos",
+    "rfpmos_hv",
+    # BJT transistors (cells/)
+    "npn13G2",
+    "npn13G2L",
+    "npn13G2V",
+    "pnpMPA",
+    # Inductors (cells/)
+    "inductor2",
+    # Via stacks (cells/)
+    "via_stack",
+    # Bondpads (cells/)
+    "bondpad",
+]
+
+
+def _has_pin_polygon_near_port(comp, port, pin_layer_tuple: tuple[int, int]) -> bool:
+    """Return True if there is at least one polygon on pin_layer_tuple near the port center."""
+    layout = comp.kcl.layout
+    layer_idx = layout.find_layer(*pin_layer_tuple)
+    if layer_idx < 0:
+        return False
+    dbu = layout.dbu
+    cx = int(port.dcenter[0] / dbu)
+    cy = int(port.dcenter[1] / dbu)
+    half = int(0.1 / dbu)
+    probe = kdb.Region(kdb.Box(cx - half, cy - half, cx + half, cy + half))
+    region = kdb.Region(comp.begin_shapes_rec(layer_idx))
+    return not (region & probe).is_empty()
+
+
+def _port_pin_layer(comp, port) -> tuple[int, int]:
+    """For IHP, port layers ARE pin layers (datatype 2 used directly)."""
+    info = comp.kcl.layout.get_info(port.layer)
+    return (info.layer, info.datatype)
+
+
+@pytest.mark.parametrize("cell_name", CELL_NAMES)
+def test_geometric_pin_present(cell_name):
+    """Each electrical port must have at least one polygon on the pin layer near it."""
+    c = PDK.cells[cell_name]()
+    electrical_ports = [p for p in c.ports if p.port_type == "electrical"]
+    assert electrical_ports, f"No electrical ports on {cell_name}"
+    for port in electrical_ports:
+        pin_layer = _port_pin_layer(c, port)
+        assert _has_pin_polygon_near_port(c, port, pin_layer), (
+            f"No geometric pin polygon near port '{port.name}' on layer {pin_layer} in {cell_name}"
+        )
+
+
+@pytest.mark.parametrize("cell_name", CELL_NAMES)
+def test_logical_pin_registered(cell_name):
+    """create_pin() must have been called — c.pins must be non-empty."""
+    c = PDK.cells[cell_name]()
+    assert len(c.pins) > 0, f"No logical pins registered on {cell_name}"
+
+
+@pytest.mark.parametrize("cell_name", CELL_NAMES)
+def test_port_type_is_electrical(cell_name):
+    """Every port on an electrical PCell must have port_type == 'electrical'."""
+    c = PDK.cells[cell_name]()
+    electrical_ports = [p for p in c.ports if p.port_type == "electrical"]
+    assert electrical_ports, f"No electrical ports found on {cell_name}"
+    for port in electrical_ports:
+        assert port.port_type == "electrical", (
+            f"Port '{port.name}' has type '{port.port_type}', expected 'electrical' in {cell_name}"
+        )


### PR DESCRIPTION
PR related to the issue in [PE-2923](https://linear.app/gdsfactory/issue/PE-2923/identify-electrical-ports-sharing-a-node-with-gfpin-objects)

## Summary

- Added `ihp/_common.py` with a shared `_add_pins` helper that draws **geometric pin rectangles** (`add_pin_rectangle_inside`) on the port's pin layer and registers **logical DPins** (`create_pin`) for all electrical ports, grouped by port name
- Applied `_add_pins(c)` before `return c` in all `@gf.cell`-decorated layout functions across `cells/` and `cells2/`: resistors (rsil, rppd, rhigh), capacitors (cmom, cmim, rfcmim), inductors, FETs, BJTs, RF transistors, via stacks, bondpads, passives, antennas, MOS transistors
- Added `tests/test_electrical_pins.py`: 54 tests verifying geometric pin polygon presence on the correct pin layer, logical pin registration, and port type correctness

## Motivation

<!-- fill in: tapeout ticket, LVS/DRC requirement, etc. -->

## Test plan

- [x] `uv run pytest tests/test_electrical_pins.py -v` — 54/54 passed
- [ ] Open a cell in KLayout and confirm pin rectangles appear on the correct pin layer (e.g. `Metal1pin` for Metal1-layer ports)
- [ ] Verify netlist export produces no `ElectricalOrphanError`

## Notes

- IHP port layers are already pin layers (datatype 2), so `_add_pins` uses `port.layer` directly — no drawing→pin mapping needed
- `inductor3` was excluded from tests due to a pre-existing `KeyError` on instantiation (unrelated to this PR)
- Schematic generator functions (`*_schematic`) are intentionally unchanged — `DSchematic` uses `s.create_port()` which already handles the schematic side; `create_pin` does not exist on `DSchematic`

## Summary by Sourcery

Ensure all IHP electrical PCells consistently expose geometric and logical electrical pins via a shared helper and accompanying tests.

New Features:
- Introduce shared _add_pins helper to add geometric pin shapes and logical pins to electrical ports on IHP PCells

Enhancements:
- Apply electrical pin generation across resistor, capacitor, inductor, transistor, via stack, bondpad, passive, and antenna layout cells in both cells/ and cells2/

Tests:
- Add electrical pin tests to validate pin polygons on correct layers, logical pin registration, and port type correctness for key IHP PCells