### PR TITLE
chore: add @MarkCunningham0410 to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @joamatab @thanojo @cdaunt @das-dias @ThomasPluck
+* @joamatab @thanojo @cdaunt @das-dias @ThomasPluck @MarkCunningham0410


### PR DESCRIPTION
Adds @MarkCunningham0410 as codeowner across all files.

## Summary by Sourcery

Chores:
- Add @MarkCunningham0410 as a code owner for all files in the repository.