### PR TITLE
test: check all ports have manhattan orientations

### DIFF
--- a/tests/test_cells.py
+++ b/tests/test_cells.py
@@ -95,6 +95,28 @@ def test_settings(component_name: str, data_regression: DataRegressionFixture) -
     data_regression.check(component.to_dict(with_ports=True))
 
 
+MANHATTAN_ORIENTATIONS = (0.0, 90.0, 180.0, 270.0)
+
+skip_test_manhattan_ports: set[str] = set()
+
+
+@pytest.mark.parametrize("component_name", cell_names)
+def test_port_orientations_manhattan(component_name: str) -> None:
+    """Ensure that all ports have a manhattan orientation (0, 90, 180 or 270 deg)."""
+    if component_name in skip_test_manhattan_ports:
+        pytest.skip(f"Skipping manhattan port orientation test for {component_name}")
+    component = cells[component_name]()
+    if isinstance(component, gf.ComponentAllAngle):
+        pytest.skip(f"{component_name} is an all-angle component")
+    for port in component.ports:
+        orientation = port.orientation % 360
+        if not np.any(np.isclose(orientation, MANHATTAN_ORIENTATIONS, atol=1e-3)):
+            raise AssertionError(
+                f"Port {port.name} of {component_name} has non-manhattan "
+                f"orientation {port.orientation} degrees."
+            )
+
+
 skip_test_models = {}
 
 


### PR DESCRIPTION
Closes #236

Adds `test_port_orientations_manhattan` to `tests/test_cells.py`, parametrized over every PDK cell (`cell_names`). For each cell it checks that every port orientation, taken mod 360, is one of 0/90/180/270 within 1e-3 degrees. Genuinely all-angle components (`gf.ComponentAllAngle`) are skipped, and a `skip_test_manhattan_ports` set is available for known issues. The check applies to electrical ports too. This is a templated rollout of the same test we are adding across our PDKs, following a pattern already reviewed and merged.

⚠️ AI-created PR: a human must review the actual code changes before merge.

## Test plan

- [ ] CI passes

## Summary by Sourcery

Tests:
- Add a parametrized test over all PDK cells to verify each port orientation is within the allowed manhattan angles, with skips for all-angle and explicitly exempted components.