### PR TITLE
docs: document missing arguments across cells and tech

### DIFF
--- a/ihp/cells/bjt_transistors.py
+++ b/ihp/cells/bjt_transistors.py
@@ -2051,6 +2051,8 @@ def contactArray(
             Length (x-dimension) of the region which contains the pin array.
         width : float
             Width (y-dimension) of the region which contains the pin array.
+        contactLayer : LayerSpec
+            Layer on which each square contact rectangle is drawn.
         xl: float
             Minimum x-coordinate of the array that contains the pins.
         yl: float

--- a/ihp/cells/fet_transistors.py
+++ b/ihp/cells/fet_transistors.py
@@ -70,8 +70,10 @@ def _place_contacts(
     Args:
         c: Component to add contacts to.
         layer_cont: Contact layer.
-        xl, yl: Lower-left of bounding box.
-        xh, yh: Upper-right of bounding box.
+        xl: X coordinate of the lower-left corner of the bounding box (um).
+        yl: Y coordinate of the lower-left corner of the bounding box (um).
+        xh: X coordinate of the upper-right corner of the bounding box (um).
+        yh: Y coordinate of the upper-right corner of the bounding box (um).
         ox: X-direction enclosure (0 for transistor S/D contacts).
         oy: Y-direction enclosure (cont_Activ_overRec for transistor S/D).
         ws: Contact size.

--- a/ihp/cells/rf_devices.py
+++ b/ihp/cells/rf_devices.py
@@ -261,6 +261,9 @@ def wilkinson_power_divider(
             Accepts a single spec for microstrip or a two-element list
             ``[lower, upper]`` for stripline.
         shape: Shape of the Wilkinson divider. Can be either "C" or "U". In a "C" shape, the quarter-wave branches are connected in a loop, while in a "U" shape, the branches are not braught together again
+        e_r: Relative permittivity of the dielectric between signal and
+            ground metals, used to derive the effective dielectric constant
+            and the line widths.
     Returns:
         A Component containing the Wilkinson power divider with ports
         ``e1`` (input), ``e2`` and ``e3`` (outputs).

--- a/ihp/cells/rf_transistors.py
+++ b/ihp/cells/rf_transistors.py
@@ -45,8 +45,10 @@ def _metal_cont(
 
     Args:
         c: Component to add geometry to.
-        p1_x, p1_y: Start point of the line (raw coordinates).
-        p2_x, p2_y: End point of the line (raw coordinates).
+        p1_x: X coordinate of the line start point, before shift_x (um).
+        p1_y: Y coordinate of the line start point, before shift_y (um).
+        p2_x: X coordinate of the line end point, before shift_x (um).
+        p2_y: Y coordinate of the line end point, before shift_y (um).
         layer_metal: Metal layer for the covering rectangle (empty string to skip).
         layer_cont: Contact/via layer for sub-rectangles.
         width: Width of the metal strip.

--- a/ihp/refs/ihp_pycell/esd_code.py
+++ b/ihp/refs/ihp_pycell/esd_code.py
@@ -29,16 +29,19 @@ def dbCreateRectArray(self, layerId, origin, n, m, x1, off1):
     """
     Creates an n x m array of rectangles.
 
-    Parameters:
-    - layerId: The layer on which to create the rectangles.
-    - origin: Tuple (x, y) specifying the lower-left corner of the first rectangle.
-    - n: Number of rows.
-    - m: Number of columns.
-    - x1: Size of each rectangle (square: x1 x x1).
-    - off1: Offset between rectangles in both X and Y directions.
+    Args:
+        self: The design object the rectangles are created on.
+        layerId: The layer on which to create the rectangles, as a Layer or
+            a layer name string.
+        origin: Tuple (x, y) specifying the lower-left corner of the first
+            rectangle.
+        n: Number of rows.
+        m: Number of columns.
+        x1: Size of each rectangle (square: x1 x x1).
+        off1: Offset between rectangles in both X and Y directions.
 
     Returns:
-    - List of created rectangle instances.
+        List of created rectangle instances.
     """
     if type(layerId) == str:
         layerId = Layer(layerId)

--- a/ihp/tech.py
+++ b/ihp/tech.py
@@ -1051,8 +1051,8 @@ def CbCapCalc(calc: str, c: float, length: float, width: float, cell: str) -> fl
         calc: "C" (capacitance from l/w), "l" (length from C/w),
               "w" (width from C/l), "lw" (square dimension from C).
         c: Capacitance in fF (used when calc != "C").
-        l: Length in um.
-        w: Width in um.
+        length: Plate length in um (used when calc is "C" or "w").
+        width: Plate width in um (used when calc is "C" or "l").
         cell: Model name ("cmim" or "rfcmim").
     """
     from math import sqrt


### PR DESCRIPTION
Closes #239

The shared pre-commit config now runs `pydocstyle --select=D417`, which requires every positional and keyword-only argument to have an entry in the docstring `Args:` / `Parameters` section.

- `contactArray`: `contactLayer`
- `_place_contacts`: split the combined `xl, yl` / `xh, yh` entries — pydocstyle does not count a combined line as documenting either name
- `wilkinson_power_divider`: `e_r`
- `_metal_cont`: split the combined `p1_x, p1_y` / `p2_x, p2_y` entries
- `CbCapCalc`: documented `l` and `w`, which are now `length` and `width`
- `dbCreateRectArray` in `refs/ihp_pycell/` is vendor reference code. Its `Parameters:` bullet list is not a section pydocstyle can parse, so it became a standard `Args:` block with the original wording preserved; only `self` is newly described.

Docstrings only; no behavior change.

## Test plan
- [ ] CI pre-commit job passes

---
Requested by @joamatab. Opened from a fork — I do not have push access to this repo. AI-authored: please review the wording of the new argument descriptions before merging.

## Summary by Sourcery

Document all previously missing function arguments so the project passes the stricter pydocstyle D417 validation.

Enhancements:
- Complete missing argument documentation across cell, RF device, technology, and vendor reference docstrings.
- Clarify individual coordinate, geometry, dielectric, and capacitor dimension parameter descriptions.

Documentation:
- Standardize the vendor reference function documentation on a parseable Args section while preserving its parameter information.