### PR TITLE
ci: add Generate nyanlib workflow and sync centralized templates

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -1,0 +1,21 @@
+name: Build PDF
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        type: string
+        required: false
+        default: ''
+        description: 'Upload PDF to this release tag (leave empty to just build)'
+
+jobs:
+  build-pdf:
+    permissions:
+      contents: write
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/build-pdf.yml@main
+    with:
+      release_tag: ${{ inputs.release_tag }}
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+      SIMCLOUD_APIKEY: ${{ secrets.SIMCLOUD_APIKEY }}

--- a/.github/workflows/gds-xor.yml
+++ b/.github/workflows/gds-xor.yml
@@ -1,0 +1,12 @@
+name: GDS XOR
+on:
+  pull_request:
+    paths:
+      - "**.gds"
+
+jobs:
+  gds-xor:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/gds-xor.yml@main

--- a/.github/workflows/generate_nyanlib.yml
+++ b/.github/workflows/generate_nyanlib.yml
@@ -1,0 +1,11 @@
+name: Generate nyanlib
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  generate:
+    uses: doplaydo/pdk-ci-workflow-public/.github/workflows/generate_nyanlib.yml@main
+    secrets:
+      GFP_API_KEY: ${{ secrets.GFP_API_KEY }}


### PR DESCRIPTION
Adds `.github/workflows/generate_nyanlib.yml` (thin wrapper around the centralized reusable workflow) so `models.nyanlib` and SVG symbols are regenerated for this repo.

`check-template-drift` brought the rest of the centralized workflow files back in line at the same time:

- added `.github/workflows/build-pdf.yml`
- added `.github/workflows/gds-xor.yml`
- added `.github/workflows/generate_nyanlib.yml`

`pre-commit run --all-files` is green except for `check-docstring-arguments`, which already fails on `main`. This diff touches only `.github/`, so it cannot have caused it — that belongs in its own PR.

Closes #241

## Summary by Sourcery

Synchronize centralized CI workflows and enable automated nyanlib generation for the repository.

New Features:
- Add repository workflows for generating nyanlib artifacts, building PDFs, and checking GDS changes.

Enhancements:
- Synchronize the repository’s GitHub Actions workflow wrappers with the centralized CI templates.

CI:
- Configure reusable workflows for nyanlib generation on main pushes or manual runs, PDF builds, and pull-request GDS XOR checks.
