### PR TITLE
ci: refresh Generate nyanlib caller from the centralized template

### DIFF
--- a/.github/workflows/generate_nyanlib.yml
+++ b/.github/workflows/generate_nyanlib.yml
@@ -9,3 +9,5 @@ jobs:
     uses: doplaydo/pdk-ci-workflow-public/.github/workflows/generate_nyanlib.yml@main
     secrets:
       GFP_API_KEY: ${{ secrets.GFP_API_KEY }}
+      GFP_GHCR_APP_ID: ${{ secrets.GFP_GHCR_APP_ID }}
+      GFP_GHCR_APP_PRIVATE_KEY: ${{ secrets.GFP_GHCR_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The centralized reusable `generate_nyanlib` workflow now authenticates to GHCR with a GitHub App token rather than the job's `GITHUB_TOKEN`, so it needs `GFP_GHCR_APP_ID` and `GFP_GHCR_APP_PRIVATE_KEY` forwarded from the caller.

Refreshed straight from `doplaydo/pdk-ci-workflow-public/templates`, no manual edits:

- updated `.github/workflows/generate_nyanlib.yml`

`pre-commit run --all-files` run twice.

## Test plan
- [ ] CI pre-commit job passes
- [ ] `Generate nyanlib` can pull the `gfp-server` image

Closes #244

## Summary by Sourcery

Update the Generate nyanlib workflow caller to support the centralized workflow’s GitHub App authentication for GHCR.

Enhancements:
- Pass GitHub App credentials to the reusable Generate nyanlib workflow so it can authenticate to GHCR using the centralized workflow’s updated authentication mechanism.

CI:
- Refresh the Generate nyanlib workflow caller configuration to forward the required GHCR credentials.